### PR TITLE
default cube size

### DIFF
--- a/components/vr-cube.js
+++ b/components/vr-cube.js
@@ -26,9 +26,9 @@
 
           getGeometry: {
             value: function() {
-              var width = parseFloat(this.getAttribute('width')) || 200;
-              var height = parseFloat(this.getAttribute('height')) || 200;
-              var depth = parseFloat(this.getAttribute('depth')) || 200;
+              var width = parseFloat(this.getAttribute('width')) || 10;
+              var height = parseFloat(this.getAttribute('height')) || 10;
+              var depth = parseFloat(this.getAttribute('depth')) || 10;
               return new THREE.BoxGeometry( width, height, depth );
             }
           },


### PR DESCRIPTION
So big that if you create a cube without dimensions, you end up not ever seeing the cube (from the inside).
