### PR TITLE
Simplify how element loading dependencies work

### DIFF
--- a/src/core/vr-node.js
+++ b/src/core/vr-node.js
@@ -43,6 +43,43 @@ module.exports = document.registerElement(
           writable: window.debug
         },
 
+        elementsLoaded: {
+          value: function(elements) {
+            return new Promise(function(resolve) {
+              function clearLoaded(tagName) {
+                var index = elements.indexOf(tagName.toUpperCase());
+                if (index !== -1) {
+                  elements.splice(index, 1);
+                };
+
+                if (elements.length === 0) {
+                  resolve();
+                }
+              };
+
+              function loadHandler(e) {
+                clearLoaded(e.target.tagName);
+              };
+
+              elements = elements.map(function(name) {
+                return name.toUpperCase();
+              });
+
+              elements.forEach(function(tagName) {
+                var element = document.querySelector(tagName);
+
+                if (element && !element.hasLoaded) {
+                  element.addEventListener('loaded', loadHandler);
+                }
+
+                if (element.hasLoaded) {
+                  clearLoaded(tagName);
+                }
+              });
+            });
+          }
+        },
+
         load: {
           value: function () {
             // To prevent emmitting the loaded event more than once


### PR DESCRIPTION
- There is no way of specifying specific element dependencies before initializing certain elements (ie vr-assets, vr-scene, vr-controls), so the user needs to listen for hasLoaded/loaded events, which can become a bit messy with components requiring several depencies:
  https://github.com/MozVR/vr-markup/blob/dev/src/core/vr-scene.js#L40, https://github.com/MozVR/vr-markup/pull/132/files#diff-083ce18fff3166a92483ea4eb8de1e70R32
- The current approach is to wait for all vr-\* elements to load before we continue rendering.   this could be troublesome for larger scenes which include external assets.    We can start to render even before these assets load.
- this would also remove similar duplicate code:
  https://github.com/MozVR/vr-markup/blob/dev/src/core/vr-assets.js#L17
