### PR TITLE
simplify attribute parsing (and fix parsing of undefined attribute values)

### DIFF
--- a/components/vr-audio.js
+++ b/components/vr-audio.js
@@ -13,8 +13,8 @@ document.registerElement(
             var listener = new THREE.AudioListener();
 
             var src = this.getAttribute('src');
-            var volume = parseFloat(this.getAttribute('vol')) || 10;
-            var loop = this.getAttribute('loop') || true;
+            var volume = this.getAttribute('vol', 10);
+            var loop = this.getAttribute('loop', false);
             var sound = new THREE.Audio(listener);
             volume = volume * 10; // We multiple by ten so the user can define volume in more intuitive scale: 0-10.
             sound.source.start(0, 0);

--- a/components/vr-cube.js
+++ b/components/vr-cube.js
@@ -28,9 +28,9 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var width = parseFloat(this.getAttribute('width')) || 5;
-            var height = parseFloat(this.getAttribute('height')) || 5;
-            var depth = parseFloat(this.getAttribute('depth')) || 5;
+            var width = this.getAttribute('width', 5);
+            var height = this.getAttribute('height', 5);
+            var depth = this.getAttribute('depth', 5);
             return new THREE.BoxGeometry(width, height, depth);
           }
         },

--- a/components/vr-curvedPlane1.js
+++ b/components/vr-curvedPlane1.js
@@ -28,9 +28,9 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius')) || 10;
-            var width = parseFloat(this.getAttribute('width')) || 4;
-            var height = parseFloat(this.getAttribute('height')) || 1;
+            var radius = this.getAttribute('radius', 10);
+            var width = this.getAttribute('width', 4);
+            var height = this.getAttribute('height', 1);
 
             var circumference = 2 * Math.PI * radius;
             var thetaLength = (Math.PI * 2) * (width / circumference);

--- a/components/vr-curvedPlane2.js
+++ b/components/vr-curvedPlane2.js
@@ -28,11 +28,11 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius')) || 10;
-            var height = parseFloat(this.getAttribute('height')) || 5;
-            var thetaStart = parseFloat(this.getAttribute('thetaStart')) || Math.PI;
-            var thetaLength = parseFloat(this.getAttribute('thetaLength')) || 90;
-            var flipNormals = parseFloat(this.getAttribute('flip')) || true;
+            var radius = this.getAttribute('radius', 10);
+            var height = this.getAttribute('height', 5);
+            var thetaStart = this.getAttribute('thetaStart', Math.PI);
+            var thetaLength = this.getAttribute('thetaLength', 90);
+            var flipNormals = this.getAttribute('flip', false);
 
             var radiusSegments = thetaLength / 2;
             var heightSegments = 1;
@@ -65,7 +65,7 @@ document.registerElement(
           value: function () {
             var imgSrc = this.getAttribute('tex');
             var color = this.getAttribute('color');
-            var opacity = parseFloat(this.getAttribute('opacity')) || 1;
+            var opacity = this.getAttribute('opacity', 1);
 
             var material = new THREE.MeshBasicMaterial({transparent: true, side: THREE.DoubleSide});
 

--- a/components/vr-cylinder.js
+++ b/components/vr-cylinder.js
@@ -28,11 +28,11 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius') || 5);
-            var height = parseFloat(this.getAttribute('height') || 1);
-            var radiusSegments = parseFloat(this.getAttribute('radiusSegments') || 36);
-            var heightSegments = parseFloat(this.getAttribute('heightSegments') || 10);
-            var openEnded = this.hasAttribute('openended');
+            var radius = this.getAttribute('radius', 5);
+            var height = this.getAttribute('height', 1);
+            var radiusSegments = this.getAttribute('radiusSegments', 36);
+            var heightSegments = this.getAttribute('heightSegments', 10);
+            var openEnded = this.getAttribute('openended', false);
 
             var geometry = new THREE.CylinderGeometry(
               radius, // radius top
@@ -49,7 +49,7 @@ document.registerElement(
 
         getMaterial: {
           value: function () {
-            var color = parseFloat(this.getAttribute('color')) || 0xCC0000;
+            var color = this.getAttribute('color', 0xCC0000);
             var materialId = this.getAttribute('material');
             var materialEl = materialId ? document.querySelector('#' + materialId) : undefined;
             return (materialEl && materialEl.material) || new THREE.MeshNormalMaterial({

--- a/components/vr-grid.js
+++ b/components/vr-grid.js
@@ -10,7 +10,7 @@ document.registerElement(
       VRObject.prototype, {
         createdCallback: {
           value: function () {
-            var color = this.getAttribute('color') || '#666';
+            var color = this.getAttribute('color', '#666');
             var material = new THREE.LineBasicMaterial({color: color});
             var geometry = this.generateGeometry();
             this.object3D = new THREE.LineSegments(geometry, material, THREE.LinePieces);
@@ -26,8 +26,8 @@ document.registerElement(
 
         generateGeometry: {
           value: function () {
-            var size = parseFloat(this.getAttribute('size') || 14);
-            var density = parseFloat(this.getAttribute('density') || 1);
+            var size = this.getAttribute('size', 14);
+            var density = this.getAttribute('density', 1);
 
             // Grid
 

--- a/components/vr-hemispherelight.js
+++ b/components/vr-hemispherelight.js
@@ -10,9 +10,9 @@ document.registerElement(
       VRObject.prototype, {
         createdCallback: {
           value: function () {
-            var skyColor = this.getAttribute('skyColor') || '#FFFFFF';
-            var groundColor = this.getAttribute('groundColor') || '#FFFFFF';
-            var intensity = parseFloat(this.getAttribute('intensity') || 1);
+            var skyColor = this.getAttribute('skyColor', '#FFFFFF');
+            var groundColor = this.getAttribute('groundColor', '#FFFFFF');
+            var intensity = this.getAttribute('intensity', 1);
             this.object3D = new THREE.HemisphereLight(skyColor, groundColor, intensity);
             this.load();
           }

--- a/components/vr-image.js
+++ b/components/vr-image.js
@@ -28,8 +28,8 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var width = parseFloat(this.getAttribute('width') || 10);
-            var height = parseFloat(this.getAttribute('height') || 10);
+            var width = this.getAttribute('width', 10);
+            var height = this.getAttribute('height', 10);
             return new THREE.PlaneGeometry(width, height, 1, 1);
           }
         },

--- a/components/vr-model.js
+++ b/components/vr-model.js
@@ -16,7 +16,7 @@ document.registerElement(
 
             // The default THREE.ColladaLoader scale of 0.01 ensures scales match across DAE and THREE scene (eg 1m - 1m)
             var scaleBase = 0.01;
-            var scaleUser = parseFloat(this.getAttribute('scale')) || 1;
+            var scaleUser = this.getAttribute('scale', {x: 1, y: 1, z: 1});
             var scale = scaleBase * scaleUser;
 
             // TODO: enable user to pass in material, and have that material apply to all nodes in the loaded object.

--- a/components/vr-plane.js
+++ b/components/vr-plane.js
@@ -28,8 +28,8 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var width = parseFloat(this.getAttribute('width')) || 10;
-            var height = parseFloat(this.getAttribute('height')) || 10;
+            var width = this.getAttribute('width', 10);
+            var height = this.getAttribute('height', 10);
             return new THREE.PlaneGeometry(width, height, 1, 1);
           }
         },

--- a/components/vr-skybox.js
+++ b/components/vr-skybox.js
@@ -28,7 +28,7 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var size = parseFloat(this.getAttribute('size')) || 10000;
+            var size = this.getAttribute('size', 10000);
             return new THREE.BoxGeometry(size, size, size, 1, 1, 1);
           }
         },

--- a/components/vr-skysphere.js
+++ b/components/vr-skysphere.js
@@ -28,7 +28,7 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius')) || 5000;
+            var radius = this.getAttribute('radius', 5000);
             return new THREE.SphereGeometry(radius, 64, 40);
           }
         },

--- a/components/vr-sphere.js
+++ b/components/vr-sphere.js
@@ -28,7 +28,7 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius')) || 5;
+            var radius = this.getAttribute('radius', 5);
             return new THREE.SphereGeometry(radius, 20, 20);
           }
         },

--- a/components/vr-video.js
+++ b/components/vr-video.js
@@ -21,8 +21,8 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var width = parseFloat(this.getAttribute('width') || 50);
-            var height = parseFloat(this.getAttribute('height') || 50);
+            var width = this.getAttribute('width', 50);
+            var height = this.getAttribute('height', 50);
             return new THREE.PlaneGeometry(width, height, 1, 1);
           }
         },
@@ -32,8 +32,8 @@ document.registerElement(
             var video = document.createElement('video');
             video.crossOrigin = 'anonymous';
             video.src = this.getAttribute('src');
-            video.autoplay = this.hasAttribute('autoplay');
-            video.loop = this.hasAttribute('loop');
+            video.autoplay = this.getAttribute('autoplay', false);
+            video.loop = this.getAttribute('loop', false);
 
             var texture = new THREE.VideoTexture(video);
             texture.minFilter = THREE.LinearFilter;

--- a/components/vr-video360.js
+++ b/components/vr-video360.js
@@ -21,7 +21,7 @@ document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius') || 10000);
+            var radius = this.getAttribute('radius', 10000);
             return new THREE.SphereGeometry(radius, 64, 40);
           }
         },
@@ -31,8 +31,8 @@ document.registerElement(
             var video = document.createElement('video');
             video.crossOrigin = 'anonymous';
             video.src = this.getAttribute('src');
-            video.autoplay = this.hasAttribute('autoplay');
-            video.loop = this.hasAttribute('loop');
+            video.autoplay = this.getAttribute('autoplay', false);
+            video.loop = this.getAttribute('loop', false);
 
             var texture = new THREE.VideoTexture(video);
             texture.minFilter = THREE.LinearFilter;

--- a/src/core/vr-camera.js
+++ b/src/core/vr-camera.js
@@ -22,11 +22,11 @@ module.exports = document.registerElement(
         attributeChangedCallback: {
           value: function () {
             // Camera parameters
-            var fov = parseFloat(this.getAttribute('fov')) || 45;
-            var near = parseFloat(this.getAttribute('near')) || 1;
-            var far = parseFloat(this.getAttribute('far')) || 10000;
-            var aspect = parseFloat(this.getAttribute('aspect')) ||
-                         window.innerWidth / window.innerHeight;
+            var fov = this.getAttribute('fov', 45);
+            var near = this.getAttribute('near', 1);
+            var far = this.getAttribute('far', 10000);
+            var aspect = this.getAttribute('aspect',
+                                           window.innerWidth / window.innerHeight);
 
             // Setting three.js camera parameters
             this.object3D.fov = fov;
@@ -41,17 +41,17 @@ module.exports = document.registerElement(
           value: function () {
             if (this.initValues) { return; }
             this.initValues = {
-              x: parseFloat(this.getAttribute('x')) || 0,
-              y: parseFloat(this.getAttribute('y')) || 0,
-              z: parseFloat(this.getAttribute('z')) || 0,
-              rotX: parseFloat(this.getAttribute('rotX')) || 0,
-              rotY: parseFloat(this.getAttribute('rotY')) || 0,
-              rotZ: parseFloat(this.getAttribute('rotZ')) || 0,
-              fov: parseFloat(this.getAttribute('fov')) || 45,
-              near: parseFloat(this.getAttribute('nar')) || 1,
-              far: parseFloat(this.getAttribute('far')) || 10000,
-              aspect: parseFloat(this.getAttribute('aspect')) ||
-                      window.innerWidth / window.innerHeight
+              x: this.getAttribute('x', 0),
+              y: this.getAttribute('y', 0),
+              z: this.getAttribute('z', 0),
+              rotX: this.getAttribute('rotX', 0),
+              rotY: this.getAttribute('rotY', 0),
+              rotZ: this.getAttribute('rotZ', 0),
+              fov: this.getAttribute('fov', 45),
+              near: this.getAttribute('nar', 1),
+              far: this.getAttribute('far', 10000),
+              aspect: this.getAttribute('aspect',
+                                        window.innerWidth / window.innerHeight)
             };
           }
         },

--- a/src/core/vr-node.js
+++ b/src/core/vr-node.js
@@ -2,6 +2,8 @@
 
 require('../vr-register-element');
 
+var VRUtils = require('../vr-utils');
+
 /**
  *
  * VRNode is the base class for all the VR markup
@@ -52,6 +54,22 @@ module.exports = document.registerElement(
             this.hasLoaded = true;
             this.dispatchEvent(event);
             if (attributeChangedCallback) { attributeChangedCallback.apply(this); }
+          },
+          writable: window.debug
+        },
+
+        setAttribute: {
+          value: function (attr, value) {
+            value = VRUtils.stringifyAttributeValue(value);
+            HTMLElement.prototype.setAttribute.call(this, attr, value);
+          },
+          writable: window.debug
+        },
+
+        getAttribute: {
+          value: function (attr, defaultValue) {
+            var value = HTMLElement.prototype.getAttribute.call(this, attr);
+            return VRUtils.parseAttributeString(attr, value, defaultValue);
           },
           writable: window.debug
         }

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -1,5 +1,3 @@
-/* global HTMLElement */
-
 require('../vr-register-element');
 
 var THREE = require('../../lib/three');
@@ -35,16 +33,16 @@ var VRObject = module.exports = document.registerElement(
           value: function () {
             this.object3D = this.object3D || new THREE.Object3D();
             // Position
-            var position = this.getAttribute('position');
+            var position = this.getAttribute('position', {x: 0, y: 0, z: 0});
 
             // Rotation
-            var rotation = this.getAttribute('rotation');
+            var rotation = this.getAttribute('rotation', {x: 0, y: 0, z: 0});
             var rotationX = THREE.Math.degToRad(rotation.x);
             var rotationY = THREE.Math.degToRad(rotation.y);
             var rotationZ = THREE.Math.degToRad(rotation.z);
 
             // Scale
-            var scale = this.getAttribute('scale');
+            var scale = this.getAttribute('scale', {x: 1, y: 1, z: 1});
 
             // Setting three.js parameters
             this.object3D.position.set(position.x, position.y, position.z);
@@ -115,13 +113,7 @@ var VRObject = module.exports = document.registerElement(
 
         setAttribute: {
           value: function (attr, val) {
-            if (typeof val === 'object' &&
-              (attr === 'position' ||
-               attr === 'rotation' ||
-               attr === 'scale')) {
-              val = [val.x, val.y, val.z].join(' ');
-            }
-            HTMLElement.prototype.setAttribute.call(this, attr, val);
+            return VRNode.prototype.setAttribute.call(this, attr, val);
           },
           writable: window.debug
         },
@@ -135,9 +127,9 @@ var VRObject = module.exports = document.registerElement(
 
         initAttributes: {
           value: function (el) {
-            var position = this.getAttribute('position');
-            var rotation = this.getAttribute('rotation');
-            var scale = this.getAttribute('scale');
+            var position = this.getAttribute('position', {x: 0, y: 0, z: 0});
+            var rotation = this.getAttribute('rotation', {x: 0, y: 0, z: 0});
+            var scale = this.getAttribute('scale', {x: 1, y: 1, z: 1});
             if (!position) { this.setAttribute('position', '0 0 0'); }
             if (!rotation) { this.setAttribute('rotation', '0 0 0'); }
             if (!scale) { this.setAttribute('scale', '1 1 1'); }
@@ -167,9 +159,8 @@ var VRObject = module.exports = document.registerElement(
         },
 
         getAttribute: {
-          value: function (attribute) {
-            var value = HTMLElement.prototype.getAttribute.call(this, attribute);
-            return VRUtils.parseAttributeString(attribute, value);
+          value: function (attrName, defaultValue) {
+            return VRNode.prototype.getAttribute.call(this, attrName, defaultValue);
           },
           writable: window.debug
         }

--- a/src/vr-animation.js
+++ b/src/vr-animation.js
@@ -1,6 +1,5 @@
 require('./vr-register-element');
 
-var VRUtils = require('./vr-utils');
 var VRNode = require('./core/vr-node');
 
 var TWEEN = require('tween.js');
@@ -11,11 +10,11 @@ module.exports = document.registerElement(
       VRNode.prototype, {
         createdCallback: {
           value: function () {
-            this.delay = parseFloat(this.getAttribute('delay')) || 0;
-            this.duration = parseFloat(this.getAttribute('duration')) || 1000;
-            this.loop = this.hasAttribute('loop');
+            this.delay = this.getAttribute('delay', 0);
+            this.duration = this.getAttribute('duration', 1000);
+            this.loop = this.getAttribute('loop', false);
             this.attribute = this.getAttribute('attribute');
-            this.to = VRUtils.parseAttributeString(this.attribute, this.getAttribute('to'));
+            this.to = this.getAttribute('to', {x: 0, y: 0, z: 0});
             this.load();
           }
         },

--- a/src/vr-controls.js
+++ b/src/vr-controls.js
@@ -39,10 +39,8 @@ module.exports = document.registerElement(
 
         attributeChangedCallback: {
           value: function () {
-            var locomotion = this.getAttribute('locomotion');
-            var mouseLook = this.getAttribute('mouse-look');
-            this.locomotion = locomotion === 'true';
-            this.mouseLook = mouseLook === 'true';
+            this.locomotion = this.getAttribute('locomotion', false);
+            this.mouseLook = this.getAttribute('mouselook', false);
           }
         },
 
@@ -60,13 +58,9 @@ module.exports = document.registerElement(
             velocity.x -= velocity.x * 10.0 * delta;
             velocity.z -= velocity.z * 10.0 * delta;
 
-            var position = this.getAttribute('position');
-            var x = position.x || 0;
-            var y = position.y || 0;
-            var z = position.z || 0;
-
-            var rotation = this.getAttribute('rotation');
-            var rotZ = rotation.z || 0;
+            var position = this.getAttribute('position', {x: 0, y: 0, z: 0});
+            var rotation = this.getAttribute('rotation', {x: 0, y: 0, z: 0});
+            var rotZ = rotation.z;
 
             if (this.locomotion) {
               if (keys[65]) { // Left
@@ -84,20 +78,11 @@ module.exports = document.registerElement(
             }
 
             if (keys[90]) { // Z
-              x = 0;
-              y = 0;
-              z = 0;
-
               this.reset();
               // scene.resetSensor();
 
-              position = this.getAttribute('position');
-              x = position.x || 0;
-              y = position.y || 0;
-              z = position.z || 0;
-
-              rotation = this.getAttribute('rotation');
-              rotZ = rotation.z || 0;
+              position = this.getAttribute('position', {x: 0, y: 0, z: 0});
+              rotation = this.getAttribute('rotation', {x: 0, y: 0, z: 0});
             }
 
             this.setAttribute('rotation', {
@@ -108,9 +93,9 @@ module.exports = document.registerElement(
 
             var movementVector = this.getMovementVector(delta);
             this.setAttribute('position', {
-              x: x + movementVector.x,
-              y: y,
-              z: z + movementVector.z
+              x: position.x + movementVector.x,
+              y: position.y,
+              z: position.z + movementVector.z
             });
           }
         },

--- a/src/vr-cursor.js
+++ b/src/vr-cursor.js
@@ -44,7 +44,7 @@ module.exports = document.registerElement(
 
         getGeometry: {
           value: function () {
-            var radius = parseFloat(this.getAttribute('radius')) || 10;
+            var radius = this.getAttribute('radius', 10);
             var geometryId = this.getAttribute('geometry');
             var geometryEl = geometryId ? document.querySelector('#' + geometryId) : undefined;
             return (geometryEl && geometryEl.geometry) || new THREE.SphereGeometry(radius, 64, 40);

--- a/src/vr-fog.js
+++ b/src/vr-fog.js
@@ -10,9 +10,9 @@ module.exports = document.registerElement(
       VRNode.prototype, {
         createdCallback: {
           value: function () {
-            var color = this.getAttribute('color') || 0xFFFFFF;
-            var near = parseFloat(this.getAttribute('near') || 1);
-            var far = parseFloat(this.getAttribute('far') || 1000);
+            var color = this.getAttribute('color', 0xFFFFFF);
+            var near = this.getAttribute('near', 1);
+            var far = this.getAttribute('far', 1000);
             this.fog = this.sceneEl.object3D.fog = new THREE.Fog(color, near, far);
             this.load();
           }

--- a/src/vr-geometry.js
+++ b/src/vr-geometry.js
@@ -18,23 +18,23 @@ module.exports = document.registerElement(
 
         setupGeometry: {
           value: function () {
-            var primitive = this.primitive = this.getAttribute('primitive') || 'Box';
+            var primitive = this.primitive = this.getAttribute('primitive', 'box').toLowerCase();
             var geometry;
             var radius;
             switch (primitive) {
-              case 'Box':
-                var width = parseFloat(this.getAttribute('width')) || 200;
-                var height = parseFloat(this.getAttribute('height')) || 200;
-                var depth = parseFloat(this.getAttribute('depth')) || 200;
+              case 'box':
+                var width = this.getAttribute('width', 200);
+                var height = this.getAttribute('height', 200);
+                var depth = this.getAttribute('depth', 200);
                 geometry = new THREE.BoxGeometry(width, height, depth);
                 break;
-              case 'Sphere':
-                radius = parseFloat(this.getAttribute('radius')) || 100;
+              case 'sphere':
+                radius = this.getAttribute('radius', 100);
                 geometry = new THREE.SphereGeometry(radius, 32, 32);
                 break;
-              case 'Torus':
-                radius = parseFloat(this.getAttribute('radius')) || 200;
-                var tube = parseFloat(this.getAttribute('tube')) || 10;
+              case 'torus':
+                radius = this.getAttribute('radius', 200);
+                var tube = this.getAttribute('tube', 10);
                 geometry = new THREE.TorusGeometry(radius, tube);
                 break;
               default:

--- a/src/vr-material.js
+++ b/src/vr-material.js
@@ -18,11 +18,9 @@ module.exports = document.registerElement(
         attributeChangedCallback: {
           value: function () {
             var color = this.getAttribute('color') || Math.random() * 0xffffff;
-            var roughness = this.getAttribute('roughness') || '1.0';
-            var metallic = this.getAttribute('metallic') || '0.5';
+            this.roughness = this.getAttribute('roughness', 1.0);
+            this.metallic = this.getAttribute('metallic', 0.5);
 
-            this.roughness = parseFloat(roughness);
-            this.metallic = parseFloat(metallic);
             this.lightIntensity = 7.001;
             color = new THREE.Color(color);
             this.color = new THREE.Vector3(color.r, color.g, color.b);

--- a/src/vr-utils.js
+++ b/src/vr-utils.js
@@ -1,29 +1,99 @@
-var error = module.exports.error = function (msg) {
+/**
+ * Throws an error given a message.
+ *
+ * @param {String} msg Error message.
+ */
+module.exports.error = function (msg) {
   throw new Error(msg);
 };
 
+/**
+ * Emits a console warning given a message.
+ *
+ * @param {String} msg Warning message.
+ */
 module.exports.warn = function (msg) {
   console.warn(msg);
 };
 
-module.exports.parseAttributeString = function (attribute, str) {
-  var values;
-  var value = str;
-  if (attribute === 'position' ||
-      attribute === 'rotation' ||
-      attribute === 'scale') {
-    if (!str) {
-      return null;
-    }
-    values = value.split(' ');
-    if (values.length !== 3) {
-      error('attr string should be len 3, ex:  (0 1 2)');
-    }
-    value = {
-      x: parseFloat(values[0]),
-      y: parseFloat(values[1]),
-      z: parseFloat(values[2])
-    };
+/**
+ * Returns the default value of an attribute based on its attribute name.
+ *
+ * @param {String} attr The name of the attribute (e.g., the string `'position'`).
+ * @returns {Object} The default value of the attribute.
+ */
+var getDefaultValue = function (attr) {
+  // Special casing for attributes whose values get transformed to objects.
+  if (attr === 'position' || attr === 'rotation' || attr === 'to') {
+    return {x: 0, y: 0, z: 0};
   }
+
+  if (attr === 'scale') {
+    return {x: 1, y: 1, z: 1};
+  }
+};
+
+/**
+ * Parse and transform an attribute value from its original string value.
+ *
+ * @param {String} attr The name of the attribute (e.g., the string `loop` for `loop="true"`).
+ * @param {String} value The value of the attribute (e.g., the string `'true'` for `loop="true"`).
+ * @param {(Boolean|Number|String|Object)} defaultValue The value to use if the attribute was missing or its value was empty (e.g., the boolean `false`).
+ * @returns {(Boolean|Number|String|Object)} The parsed and coerced value of the attribute (e.g., the boolean `true` for `loop="true"`).
+ */
+module.exports.parseAttributeString = function (attr, value, defaultValue) {
+  if (!attr) { return; }
+
+  var valueLower = (value || '').toLowerCase();
+  var values = '';
+
+  if (typeof defaultValue === 'undefined') {
+    defaultValue = getDefaultValue(attr);
+  }
+
+  if (typeof defaultValue === 'object') {
+    if ('x' in defaultValue && 'y' in defaultValue && 'z' in defaultValue) {
+      if (!value) { return null; }
+
+      values = value.split(' ');
+
+      return {
+        x: parseFloat(values[0] || defaultValue.x),
+        y: parseFloat(values[1] || defaultValue.y),
+        z: parseFloat(values[2] || defaultValue.z)
+      };
+    }
+  }
+
+  if (value === '' || value === null || typeof value === 'undefined') {
+    return typeof defaultValue === 'undefined' ? null : defaultValue;
+  }
+
+  if (typeof defaultValue === 'number') {
+    return parseFloat(value);
+  }
+
+  if (typeof defaultValue === 'boolean') {
+    return valueLower === 'true';
+  }
+
   return value;
+};
+
+/**
+ * Transform and stringify an attribute value to a string based on its original value.
+ *
+ * @param {(Boolean|Number|String|Object)} value The value of the attribute (e.g., `{x: 5, y: 10, z: 15}` in `setAttribute('position', {x: 5, y: 10, z: 15})`).
+ * @returns {String} The transformed and stringified value of the attribute (e.g., `5 10 15` for `position="5 10 15"`).
+ */
+module.exports.stringifyAttributeValue = function (value) {
+  if (typeof value === 'object') {
+    if ('x' in value && 'y' in value && 'z' in value) {
+      return [value.x, value.y, value.z].join(' ');
+    }
+
+    return JSON.stringify(value);
+  }
+
+  return String(value);
 };

--- a/test/vr-object.js
+++ b/test/vr-object.js
@@ -439,18 +439,96 @@ suite('vr-object', function () {
       this.el = null;
     });
 
-    test('returns null for a not defined attribute', function () {
+    test('returns null for an undefined attribute', function () {
       var el = this.el;
-      var height = el.getAttribute('height');
-      assert.isNull(height);
+      assert.notInclude(el.outerHTML, 'loop=');
+      assert.isNull(el.getAttribute('loop'));
     });
 
-    test('returns correct value for a defined attribute', function () {
+    test('returns correct value for an undefined boolean attribute with a default', function () {
+      var el = this.el;
+      el.removeAttribute('autoplay');
+      assert.notInclude(el.outerHTML, 'autoplay=');
+      assert.isTrue(el.getAttribute('autoplay', true));
+    });
+
+    test('returns correct value for an undefined number attribute with a default', function () {
+      var el = this.el;
+      assert.notInclude(el.outerHTML, 'height=');
+      assert.equal(el.getAttribute('height', 2.0), 2.0);
+    });
+
+    test('returns correct value for an undefined object attribute with a default', function () {
+      var el = this.el;
+      assert.notInclude(el.outerHTML, 'voodoo=');
+      var val = {x: 5, y: 10, z: 15};
+      assert.isNull(el.getAttribute('voodoo', val));
+    });
+
+    test('returns correct default for "position" attribute', function () {
+      var el = this.el;
+      assert.include(el.outerHTML, 'position="0 0 0"');
+      assert.deepEqual(el.getAttribute('position'), {x: 0, y: 0, z: 0});
+    });
+
+    test('returns correct default for "rotation" attribute', function () {
+      var el = this.el;
+      assert.include(el.outerHTML, 'rotation="0 0 0"');
+      assert.deepEqual(el.getAttribute('rotation'), {x: 0, y: 0, z: 0});
+    });
+
+    test('returns correct default for "scale" attribute', function () {
+      var el = this.el;
+      assert.include(el.outerHTML, 'scale="1 1 1"');
+      assert.deepEqual(el.getAttribute('scale'), {x: 1, y: 1, z: 1});
+    });
+
+    test('returns correct value for a defined "position" attribute', function () {
       var el = this.el;
       var positionObj = {x: 23, y: 24, z: 25};
       el.setAttribute('position', positionObj);
+      assert.include(el.outerHTML, 'position="23 24 25"');
       var position = el.getAttribute('position');
       assert.deepEqual(position, positionObj);
+    });
+
+    test('returns correct value for a defined "rotation" attribute', function () {
+      var el = this.el;
+      var rotationObj = {x: 3, y: 2, z: 1};
+      el.setAttribute('rotation', rotationObj);
+      assert.include(el.outerHTML, 'rotation="3 2 1"');
+      var rotation = el.getAttribute('rotation');
+      assert.deepEqual(rotation, rotationObj);
+    });
+
+    test('returns correct value for a defined "to" attribute', function () {
+      var el = this.el;
+      el.setAttribute('to', '5');
+      assert.deepEqual(el.getAttribute('to'), {x: 5, y: 0, z: 0});
+    });
+
+    test('returns correct value for a boolean attribute with a default', function () {
+      var el = this.el;
+      var val = true;
+      el.setAttribute('loop', val);
+      assert.include(el.outerHTML, 'loop="true"');
+      assert.isTrue(el.getAttribute('loop', false));
+    });
+
+    test('returns correct value for a number attribute with a default', function () {
+      var el = this.el;
+      var val = 5.9;
+      el.setAttribute('height', val);
+      assert.include(el.outerHTML, 'height="5.9"');
+      assert.equal(el.getAttribute('height', 2.0), val);
+    });
+
+    test('returns correct value for an object attribute with a default', function () {
+      var el = this.el;
+      el.setAttribute('voodoo', '5 10 15');
+      assert.include(el.outerHTML, 'voodoo="5 10 15"');
+      var val = {x: 5, y: 10, z: 15};
+      assert.deepEqual(el.getAttribute('voodoo', val), val);
     });
   });
 });


### PR DESCRIPTION
- more DRY
- made boolean attributes consistent (we can change to `'true'`/`'false'` later, despite that not being a standard)
- fixes some bugs when attributes were blank, missing, or zero

what's needed?
- just unit tests :yum: :mask: 
