### PR TITLE
use different pre-commit library, add linter to dev server/watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
-    "budo": "^4.2.1",
+    "budo": "mattdesl/budo#6372153",
     "crass": "^0.7.7",
-    "garnish": "^2.3.0",
+    "garnish": "^3.2.0",
     "gh-pages": "^0.4.0",
+    "husky": "^0.10.1",
     "karma": "^0.13.9",
     "karma-browserify": "4.3.0",
     "karma-chai-shallow-deep-equal": "0.0.4",
@@ -22,7 +23,6 @@
     "karma-mocha-reporter": "^1.1.0",
     "karma-sinon-chai": "^1.1.0",
     "mozilla-download": "^1.0.5",
-    "pre-commit": "^1.1.1",
     "replace": "^0.3.0",
     "semistandard": "^7.0.2",
     "snazzy": "^2.0.1",
@@ -30,7 +30,7 @@
   },
   "scripts": {
     "start": "npm run dev",
-    "dev": "npm run build && budo src/vr-markup.js:build/vr-markup.js --debug --verbose --live --port 9000 -- -r ./src/vr-markup.js:vr-markup | garnish -v",
+    "dev": "npm run build && budo src/vr-markup.js:build/vr-markup.js --debug --verbose --live --port 9000 --onupdate 'semistandard -v $(git ls-files '*.js') | snazzy' -- -r ./src/vr-markup.js:vr-markup | garnish -v",
     "build": "mkdir -p build && browserify -r ./src/vr-markup.js:vr-markup -o build/vr-markup.js --debug",
     "dist": "rm -rf dist/ && mkdir -p dist/ && npm run dist:js:dev && npm run dist:js:min && npm run dist:css:dev && npm run dist:css:min &&  git commit -am 'Bump dist'",
     "dist:js:dev": "browserify -r ./src/vr-markup.js:vr-markup -o dist/vr-markup.js --debug",
@@ -44,7 +44,8 @@
     "release": "npm version patch --minor && npm login && npm publish",
     "test": "karma start ./test/karma.conf.js",
     "test:ci": "karma start ./test/karma.conf.js --single-run",
-    "lint": "semistandard -v | snazzy"
+    "lint": "semistandard -v $(git ls-files '*.js') | snazzy",
+    "precommit": "npm run lint"
   },
   "repository": "MozVR/vr-markup",
   "bugs": {
@@ -58,6 +59,5 @@
       "lib/vendor/**",
       "src/shaders/**"
     ]
-  },
-  "pre-commit": "lint"
+  }
 }


### PR DESCRIPTION
Leaving the line in the `package.json` in case people have `pre-commit` already installed (so it doesn't run `npm test` on every commit).

If you'd like to remove the hook:

```
rm .git/hooks/pre-commit
```
