### PR TITLE
specify required versions of npm and node

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,5 +60,9 @@
       "lib/vendor/**",
       "src/shaders/**"
     ]
+  },
+  "engines": {
+    "node" : ">= 0.12.7",
+    "npm": ">= 2.12.1"
   }
 }


### PR DESCRIPTION
private modules were introduced in only npm 2.x
