### PR TITLE
allow setting custom attributes as data attributes (to support React)

### DIFF
--- a/src/core/vr-node.js
+++ b/src/core/vr-node.js
@@ -68,7 +68,10 @@ module.exports = document.registerElement(
 
         getAttribute: {
           value: function (attr, defaultValue) {
-            var value = HTMLElement.prototype.getAttribute.call(this, attr);
+            var getAttr = HTMLElement.prototype.getAttribute;
+            // Support both custom attribute name and data- attribute name.
+            var value = getAttr.call(this, 'data-' + attr) ||
+                        getAttr.call(this, attr);
             return VRUtils.parseAttributeString(attr, value, defaultValue);
           },
           writable: window.debug

--- a/test/vr-object.js
+++ b/test/vr-object.js
@@ -530,5 +530,24 @@ suite('vr-object', function () {
       var val = {x: 5, y: 10, z: 15};
       assert.deepEqual(el.getAttribute('voodoo', val), val);
     });
+
+    test('returns correct value for string data attributes', function () {
+      var el = this.el;
+      var expectedDepth = '50';
+      el.setAttribute('data-depth', expectedDepth);
+      var depth = el.getAttribute('depth');
+      assert.deepEqual(depth, expectedDepth);
+    });
+
+    test('returns correct value for XYZ data attributes', function () {
+      var self = this;
+      ['position', 'rotation', 'scale'].forEach(function (attrName) {
+        var el = self.el;
+        var attrObj = {x: 23, y: 24, z: 25};
+        el.setAttribute('data-' + attrName, attrObj);
+        var attr = el.getAttribute(attrName);
+        assert.deepEqual(attr, attrObj);
+      });
+    });
   });
 });


### PR DESCRIPTION
I was playing around with vr-markup + React, but React doesn't support custom attributes. However, React does support data attributes. This PR will add flexibility to use either the custom attribute name or the attribute name prepended by data-.
