### PR TITLE
fix tests related to getAttribute (#181)

### DIFF
--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -6,7 +6,7 @@ var VRUtils = require('../vr-utils');
 
 /**
  *
- * VROBject represents all elements that are part of the 3D scene.
+ * VRObject represents all elements that are part of the 3D scene.
  * They all have a position, rotation and a scale.
  *
  */
@@ -127,9 +127,9 @@ var VRObject = module.exports = document.registerElement(
 
         initAttributes: {
           value: function (el) {
-            var position = this.getAttribute('position', {x: 0, y: 0, z: 0});
-            var rotation = this.getAttribute('rotation', {x: 0, y: 0, z: 0});
-            var scale = this.getAttribute('scale', {x: 1, y: 1, z: 1});
+            var position = this.hasAttribute('position');
+            var rotation = this.hasAttribute('rotation');
+            var scale = this.hasAttribute('scale');
             if (!position) { this.setAttribute('position', '0 0 0'); }
             if (!rotation) { this.setAttribute('rotation', '0 0 0'); }
             if (!scale) { this.setAttribute('scale', '1 1 1'); }

--- a/test/vr-object.js
+++ b/test/vr-object.js
@@ -48,13 +48,13 @@ suite('vr-object', function () {
     });
 
     test('is called on attribute changed', function (done) {
-      var el = this.el;
+      var el = this.el
       var position = {x: 0, y: 10, z: 0};
       el.setAttribute('position', position);
       process.nextTick(function () {
         sinon.assert.calledWith(
           VRObject.prototype.attributeChangedCallback,
-          'position', '0 0 0', position);
+          'position', null, position);
         done();
       });
     });
@@ -345,10 +345,10 @@ suite('vr-object', function () {
       assert.deepEqual(position, positionObj);
     });
 
-    test('position is set to null when passing an empty string', function () {
+    test('defaults position to 0 0 0', function () {
       this.el.setAttribute('position', '');
       var position = this.el.getAttribute('position');
-      assert.isNull(position);
+      assert.deepEqual(position, {x: 0, y:0, z:0});
     });
   });
 
@@ -462,7 +462,7 @@ suite('vr-object', function () {
       var el = this.el;
       assert.notInclude(el.outerHTML, 'voodoo=');
       var val = {x: 5, y: 10, z: 15};
-      assert.isNull(el.getAttribute('voodoo', val));
+      assert.equal(el.getAttribute('voodoo', val), val);
     });
 
     test('returns correct default for "position" attribute', function () {


### PR DESCRIPTION
Janitorial work:
- Test regressions from https://github.com/MozVR/vr-markup/commit/f53d34b430c46d8b8e95a87e79ccc71e8d65d96a
- Since getAttribute now returns the second value as the default, needed to change initAttributes to use hasAttribute, since getAttribute would always return a truthy value.
