### PR TITLE
Handle different Object3D types, adds geometry and materials.

### DIFF
--- a/examples/cubes.html
+++ b/examples/cubes.html
@@ -15,6 +15,7 @@
     <vr-object position="-10 0 0" rotation="0 45 0" geometry="primitive: box" material="color: red"></vr-object>
     <vr-object position="0 0 0" rotation="0 45 0" geometry="primitive: box" material="color: green"></vr-object>
     <vr-object class="cube" position="10 0 0" rotation="0 45 0" geometry="primitive: box" material="color: blue"></vr-object>
+    <vr-object position="0 -2.5 0" rotation="0 0 0" geometry="primitive: grid" material="color: grey"></vr-object>
   </vr-scene>
 </body>
 </html>

--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -1,5 +1,4 @@
 var registerComponent = require('../core/register-component');
-var THREE = require('../../lib/three');
 
 var defaults = {
   fov: 45,
@@ -10,7 +9,7 @@ var defaults = {
 module.exports.Component = registerComponent('camera', {
   init: {
     value: function () {
-      this.setupCamera();
+      this.camera = this.el.getObject3D('PerspectiveCamera');
     }
   },
 
@@ -24,14 +23,6 @@ module.exports.Component = registerComponent('camera', {
       camera.far = data.far || defaults.far;
       camera.aspect = data.aspect || window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
-    }
-  },
-
-  setupCamera: {
-    value: function () {
-      var el = this.el;
-      var camera = this.camera = new THREE.PerspectiveCamera();
-      el.object3D.add(camera);
     }
   }
 });

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -12,7 +12,7 @@ var defaults = {
 module.exports.Component = registerComponent('geometry', {
   update: {
     value: function () {
-      var object3D = this.el.object3D;
+      var object3D = this.el.getObject3D('Mesh');
       object3D.geometry = this.setupGeometry();
     }
   },

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -23,16 +23,24 @@ module.exports.Component = registerComponent('geometry', {
       var primitive = data.primitive;
       var geometry;
       var radius;
+      var width;
+      var height;
+      var depth;
       switch (primitive) {
         case 'box':
-          var width = data.width || defaults.size;
-          var height = data.height || defaults.size;
-          var depth = data.depth || defaults.size;
+          width = data.width || defaults.size;
+          height = data.height || defaults.size;
+          depth = data.depth || defaults.size;
           geometry = new THREE.BoxGeometry(width, height, depth);
           break;
         case 'sphere':
           radius = data.radius || defaults.size;
           geometry = new THREE.SphereGeometry(radius, defaults.segments, defaults.segments);
+          break;
+        case 'plane':
+          width = data.width || defaults.size;
+          height = data.height || defaults.size;
+          geometry = new THREE.PlaneGeometry(width, height, 1, 1);
           break;
         case 'torus':
           radius = data.radius || defaults.radius;

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -12,8 +12,7 @@ var defaults = {
 module.exports.Component = registerComponent('geometry', {
   update: {
     value: function () {
-      var object3D = this.el.getObject3D('Mesh');
-      object3D.geometry = this.setupGeometry();
+      this.setupGeometry();
     }
   },
 
@@ -26,7 +25,12 @@ module.exports.Component = registerComponent('geometry', {
       var width;
       var height;
       var depth;
+      var object3D = this.el.getObject3D('Mesh');
       switch (primitive) {
+        case 'grid':
+          object3D = this.el.getObject3D('LineSegments');
+          geometry = this.setupGridGeometry();
+          break;
         case 'box':
           width = data.width || defaults.size;
           height = data.height || defaults.size;
@@ -52,7 +56,26 @@ module.exports.Component = registerComponent('geometry', {
           VRUtils.warn('Primitive type not supported');
           break;
       }
-      this.geometry = geometry;
+      object3D.geometry = geometry;
+    }
+  },
+
+  setupGridGeometry: {
+    value: function () {
+      var size = this.data.size || 14;
+      var density = this.data.density || 1;
+
+      // Grid
+      var geometry = new THREE.Geometry();
+
+      for (var i = -size; i <= size; i += density) {
+        geometry.vertices.push(new THREE.Vector3(-size, -0.04, i));
+        geometry.vertices.push(new THREE.Vector3(size, -0.04, i));
+
+        geometry.vertices.push(new THREE.Vector3(i, -0.04, -size));
+        geometry.vertices.push(new THREE.Vector3(i, -0.04, size));
+      }
+
       return geometry;
     }
   }

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -19,26 +19,41 @@ module.exports.Component = registerComponent('material', {
   update: {
     value: function () {
       var data = this.data;
-      var object3D = this.el.getObject3D('Mesh');
+      var object3D = this.el.getObject3D();
       var type = data.type || defaults.type;
       var color = data.color || defaults.color;
       color = new THREE.Color(color);
-      color = new THREE.Vector3(color.r, color.g, color.b);
       var material = this.material;
+
+      if (object3D instanceof THREE.LineSegments) {
+        type = 'lineBasic';
+      }
+
       switch (type) {
+        case 'lineBasic':
+          material = this.setupLineBasicMaterial();
+          material.color.set(color);
+          object3D.material = this.material = material;
+          break;
         case 'meshNormal':
           material = this.setupMeshNormalMaterial();
           object3D.material = this.material = material;
           break;
         case 'pbr':
           material = this.setupPbrMaterial();
-          material.uniforms.baseColor.value = color;
+          material.uniforms.baseColor.value = new THREE.Vector3(color.r, color.g, color.b);
           material.uniforms.roughness.value = data.roughness || defaults.roughness;
           material.uniforms.metallic.value = data.metallic || defaults.metallic;
           material.uniforms.lightIntensity.value = data.lightIntensity || defaults.lightIntensity;
           object3D.material = this.material = material;
           break;
       }
+    }
+  },
+
+  setupLineBasicMaterial: {
+    value: function () {
+      return new THREE.LineBasicMaterial();
     }
   },
 

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -12,21 +12,19 @@ var defaults = {
 module.exports.Component = registerComponent('material', {
   init: {
     value: function () {
+      this.update();
     }
   },
 
   update: {
     value: function () {
       var data = this.data;
-      var object3D = this.el.object3D;
+      var object3D = this.el.getObject3D('Mesh');
       var type = data.type || defaults.type;
       var color = data.color || defaults.color;
       color = new THREE.Color(color);
       color = new THREE.Vector3(color.r, color.g, color.b);
       var material = this.material;
-      if (material !== undefined) {
-        return;
-      }
       switch (type) {
         case 'meshNormal':
           material = this.setupMeshNormalMaterial();

--- a/src/components/position.js
+++ b/src/components/position.js
@@ -3,7 +3,7 @@ var registerComponent = require('../core/register-component');
 module.exports.Component = registerComponent('position', {
   update: {
     value: function () {
-      var object3D = this.el.object3D;
+      var object3D = this.el.getObject3D();
       var data = this.data;
       // Updates three.js object
       object3D.position.set(data.x, data.y, data.z);

--- a/src/components/rotation.js
+++ b/src/components/rotation.js
@@ -5,7 +5,7 @@ module.exports.Component = registerComponent('rotation', {
   update: {
     value: function () {
       var data = this.data;
-      var object3D = this.el.object3D;
+      var object3D = this.el.getObject3D();
       // Updates three.js object
       var rotationX = THREE.Math.degToRad(data.x);
       var rotationY = THREE.Math.degToRad(data.y);

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -10,7 +10,11 @@ var flattenAttributes = function (attrs) {
   var obj = {};
   attrs.forEach(flatten);
   function flatten (attr) {
-    obj[attr.name] = attr.value[1].value;
+    // filter white space values
+    attr.value = attr.value.filter(function (att) {
+      return att.value !== undefined;
+    });
+    obj[attr.name] = attr.value[0].value;
   }
   return obj;
 };

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -160,16 +160,40 @@ var proto = {
     writable: window.debug
   },
 
+  /**
+   * Returns Object3D attatched to this entity based on type.  If type is left blank,
+   * the method will return the current Object3D.  If none exists, it will create and
+   * return a new Mesh.
+   *
+   * @type {String} Type of Object3D being requested.
+   */
   getObject3D: {
     value: function (type) {
+      // Object3D type to be create by default
+      var defaultType = 'Mesh';
+
+      // return current Object3D if type is not specified.
+      if (this.currentObject3D && !type) {
+        return this.currentObject3D;
+      }
+
+      // finds children of specific Object3D type.
       var obj = this.object3D.children.filter(function (child) {
         return child.type === type;
       })[0];
 
+      // Create new Object3D of type
       if (!obj) {
-        obj = new THREE[type]();
+        obj = new THREE[type || defaultType]();
         this.object3D.add(obj);
       }
+
+      // Replace existing Object3D.
+      if (obj !== this.currentObject3D) {
+        this.object3D.remove(this.currentObject3D);
+      }
+      this.currentObject3D = obj;
+
       return obj;
     }
   }

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -18,7 +18,7 @@ var proto = {
   //  ----------------------------------  //
   attachedCallback: {
     value: function () {
-      this.object3D = new THREE.Mesh();
+      this.object3D = new THREE.Object3D();
       this.components = {};
       this.addToParent();
       this.load();
@@ -158,6 +158,20 @@ var proto = {
       return VRNode.prototype.getAttribute.call(this, attrName, defaultValue);
     },
     writable: window.debug
+  },
+
+  getObject3D: {
+    value: function (type) {
+      var obj = this.object3D.children.filter(function (child) {
+        return child.type === type;
+      })[0];
+
+      if (!obj) {
+        obj = new THREE[type]();
+        this.object3D.add(obj);
+      }
+      return obj;
+    }
   }
 };
 


### PR DESCRIPTION
The big change here is that the vr-object element now uses THREE.Object3D as a base object type.   We then attach child Object3D types to this that components can request and use.

This change allows us to support multiply object3D types like PerspectiveCamera, LineSegments, AmbientLight, etc.

Components should now access Object3D using the `el.getObject3D()` method.    As a option, you can specify a Object3D type ie:  `el.getObject3D('PerspectiveCamera')`, and it will return a new object of that type.   If none is specified, then by default, it will return a Mesh.
