### PR TITLE
add light component

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -44,6 +44,7 @@
       <li><a href="controls/">Controls</a></li>
       <li><a href="cursor/">Cursor</a></li>
       <li><a href="cubes/">Cubes</a></li>
+      <li><a href="lights/">Lights</a></li>
       <li><a href="mixin/">Mixin</a></li>
       <li><a href="texture/">Texture</a></li>
       <li><a href="panoexplorer/">Pano Explorer</a></li>

--- a/examples/lights/index.html
+++ b/examples/lights/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Light Component</title>
+  <meta name="description" content="Light Component">
+  <link rel="stylesheet" type="text/css" href="../../style/vr-markup.css">
+  <link rel="stylesheet" type="text/css" href="../_style/main.css">
+  <script src="../../build/vr-markup.js"></script>
+</head>
+
+<body>
+  <vr-assets>
+    <vr-mixin id="orbit" attribute="rotation" to="1 0.2 0.2"
+              repeat="indefinite" easing="linear" dur="10000"></vr-mixin>
+  </vr-assets>
+  <vr-scene>
+    <!-- Camera. -->
+    <vr-object position="0 0 20" camera="fov: 45"
+               controls="mouselook: true; locomotion: true"></vr-object>
+
+    <vr-object light="color: #CCCCFF; intensity: 15"
+               position="-10 10 10" rotation="-0.2 0.2 0.2">
+      <vr-animation mixin="orbit"></vr-animation>
+    </vr-object>
+
+    <!-- Lit objects. -->
+    <vr-object position="-10 0 0" geometry="primitive: sphere; radius: 3"
+               material="color: red; metallic: 1"></vr-object>
+    <vr-object position="-20 0 0" geometry="primitive: sphere; radius: 3"
+               material="color: purple; roughness: 1"></vr-object>
+    <vr-object position="0 0 0" rotation="0 45 0" geometry="primitive: box"
+               material="color: green; metallic: .8"></vr-object>
+    <vr-object position="10 0 0" rotation="0 0 45" geometry="primitive: box"
+               material="color: blue; roughness: 1; metallic: 0"></vr-object>
+  </vr-scene>
+</body>
+</html>

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -1,0 +1,55 @@
+var registerComponent = require('../core/register-component').registerComponent;
+var THREE = require('../../lib/three');
+
+var id = 1;
+
+/**
+ * Light component.
+ * Passes up light attributes to the vr-object.
+ * vr-object will pass the light to vr-scene.
+ * vr-scene will keep track of all the lights, and handle updating materials.
+ *
+ * Light direction and position are determined by its entity's rotation and
+ * position.
+ *
+ * To support PBR, currently not using three.js lights. PBR materials are not
+ * yet officially implemented by three.js.
+ *
+ * @param {string} color - light color.
+ * @param {number} intensity - light strength.
+ */
+module.exports.Component = registerComponent('light', {
+  defaults: {
+    value: {
+      color: '#ffffff',
+      intensity: 1.0
+    }
+  },
+
+  /**
+   * Give light ID so scene can keep track of this light and make changes in
+   * place.
+   */
+  init: {
+    value: function () {
+      this.id = this.id || id++;
+      this.update();
+    }
+  },
+
+  /**
+   * Tells the light component's entity to tell the scene to update the light.
+   */
+  update: {
+    value: function () {
+      if (!this.data) { return; }
+
+      var color = new THREE.Color(this.data.color);
+      this.el.registerLight({
+        id: this.id,
+        color: new THREE.Vector3(color.r, color.g, color.b),
+        intensity: this.data.intensity
+      });
+    }
+  }
+});

--- a/src/core/components.js
+++ b/src/core/components.js
@@ -3,6 +3,7 @@ module.exports.components = require('../core/register-component').components;
 require('../components/camera');
 require('../components/controls');
 require('../components/geometry');
+require('../components/light');
 require('../components/material');
 require('../components/position');
 require('../components/raycaster');

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -31,6 +31,7 @@ var proto = {
       this.object3D = new THREE.Mesh();
       this.components = {};
       this.states = [];
+      this.light = null;
       this.addToParent();
       this.load();
     },
@@ -52,6 +53,7 @@ var proto = {
       // if old and new values are the same
       var newValStr = newVal;
       var component = VRComponents[attr];
+      var light = this.light;
       if (component && typeof newVal !== 'string') {
         newValStr = component.stringifyAttributes(newVal);
       }
@@ -62,6 +64,9 @@ var proto = {
         return;
       }
       this.updateComponent(attr);
+      if (light && ['position', 'rotation'].indexOf(attr) !== -1) {
+        this.registerLight(light);
+      }
     },
     writable: window.debug
   },
@@ -236,8 +241,8 @@ var proto = {
       var component = this.components[name];
       // Update if component already initialized
       if (component) {
+        // TODO: update component attribute more granularly.
         component.updateAttributes();
-        VRUtils.log('Component updated: ' + name);
         return;
       }
       this.initComponent(name);
@@ -296,6 +301,25 @@ var proto = {
       return is;
     },
     writable: window.debug
+  },
+
+  /**
+   * Registers light component data to the vr-scene.
+   * Attaches entity's position/rotation to the light component data.
+   * Use entity's rotation as light's direction.
+   *
+   * @param {object} light - light attributes (e.g., color, intensity).
+   */
+  registerLight: {
+    value: function (light) {
+      if (!this.light) {
+        // Store the light in case the entity's position or rotation changes.
+        this.light = light;
+      }
+      light.direction = this.getAttribute('rotation');
+      light.position = this.getAttribute('position');
+      this.sceneEl.registerLight(light);
+    }
   }
 };
 

--- a/src/shaders/pbrFragment.glsl
+++ b/src/shaders/pbrFragment.glsl
@@ -1,137 +1,206 @@
 /**
- * http://www.alexandre-pestana.com/webgl/PBRViewer.html
+ * PBR Fragment Shader.
+ *
+ * Uses Cook-Torrance Model BRDF for physical accuracy.
+ *  kSpec = DFG / 4 * (V dot N) * (N dot L)
+ *    Microfacet slope (D)istribution, (F)resnel term, (G)eometric attenuation,
+ *    (V)iewing position, (N)ormal vector, (L)ight direction vector.
+ *  D - distribution of orientation of microfacets.
+ *  F - how reflectivity will change at grazing angles.
+ *  G - probability a microfacet will be visible.
+ *
+ * @param baseColor (vec3)
+ * @param lightColors (array of vec3)
+ * @param lightDirections (array of vec3)
+ * @param lightIntensities (array of int)
+ * @param lightPositions (array of vec3)
+ * @param metallic (float)
+ * @param roughness (float)
+ *
+ * Currently supports directional light.
+ * TODO: add support and defaults for ambient lighting.
+ * TODO: add support for point light, light positions are present but unused.
+ *
+ * Originally adapted from: alexandre-pestana.com/webgl/PBRViewer.html
+ * Modified to handle multiple lights, taking lightArraySize as a templated
+ * parameter.
+ * Refined PBR models with: de45xmedrsdbp.cloudfront.net/Resources/files/
+ *                            2013SiggraphPresentationsNotes-26915738.pdf
  */
 #define PI 3.14159265359
 
+uniform vec3 baseColor;
 uniform samplerCube envMap0;
 uniform samplerCube envMap1;
 uniform samplerCube envMap2;
 uniform samplerCube envMap3;
 uniform samplerCube envMap4;
 uniform samplerCube envMap5;
-uniform vec3 baseColor;
-
-uniform float roughness;
+uniform vec3 lightColors[{{lightArraySize}}];
+uniform vec3 lightDirections[{{lightArraySize}}];
+uniform int lightIntensities[{{lightArraySize}}];
+uniform vec3 lightPositions[{{lightArraySize}}];
 uniform float metallic;
-uniform float lightIntensity;
+uniform float roughness;
 
 varying vec2 vUv;
 varying mat3 tbn;
-varying vec3 vLightVector;
-varying vec3 vTestNormal;
 varying vec3 vPosition;
+varying vec3 vTestNormal;
 
-vec3 Diffuse(vec3 pAlbedo) {
+vec3 diffuse(vec3 pAlbedo) {
   return pAlbedo/PI;
 }
 
-//---------- Normal distribution functions ------------//
-float NormalDistribution_GGX(float a, float NdH) {
-  // Isotropic ggx.
-  float a2 = a*a;
+/*
+ * Microfacet slope distribution (i.e., roughness) using Isotropic w/ GGX.
+ *
+ * @param roughness (float) controls roughness of surface via alpha value.
+ *        On rough surfaces, the light is widely distributed. On smooth
+ *        surfaces, microfacets have similar orientation and light reflected
+ *        closed to reflection V.
+ */
+float specularDistribution(float roughness, float NdH) {
+  float roughnessSquared = roughness * roughness;
   float NdH2 = NdH * NdH;
-            float denominator = NdH2 * (a2 - 1.0) + 1.0;
+  float denominator = NdH2 * (roughnessSquared - 1.0) + 1.0;
   denominator *= denominator;
   denominator *= PI;
-	return a2 / denominator;
+	return roughnessSquared / denominator;
 }
 
-//---------- Geometric shadowing ------------//
-float Geometric_Smith_Schlick_GGX(float a, float NdV, float NdL) {
-  // Smith schlick-GGX.
+/*
+ * Fresnel using Schlick's approximation.
+ * Defines fraction of incoming light reflected and fraction transmitted.
+ */
+vec3 specularFresnel(vec3 specularColor, vec3 h, vec3 v) {
+  return (
+    specularColor + (1.0 - specularColor) *
+    pow((1.0 - clamp(dot(v, h), 0.0, 1.0)), 5.0)
+  );
+}
+
+/*
+ * Fresnel for reflection.
+ */
+vec3 specularFresnelRoughness(vec3 specularColor, float a, vec3 h, vec3 v) {
+  return (
+    specularColor + (max(vec3(1.0 - a), specularColor) - specularColor) *
+    pow((1.0 - clamp(dot(v, h), 0.0, 1.0)), 5.0)
+  );
+}
+
+/*
+ * Geometric attenuation/shadowing using Smith/Sclick with GGX.
+ */
+float specularGeometricAttenuation(float a, float NdV, float NdL, float NdH,
+                                   float VdH, float LdV) {
   float k = a * 0.5;
   float GV = NdV / (NdV * (1.0 - k) + k);
   float GL = NdL / (NdL * (1.0 - k) + k);
   return GV * GL;
 }
 
-//---------- Fresnel ------------//
-vec3 Fresnel_Schlick(vec3 specularColor, vec3 h, vec3 v) {
-  return (specularColor + (1.0 - specularColor) * pow((1.0 - clamp(dot(v, h), 0.0, 1.0)), 5.0));
+/*
+ * Computes specular contribution of a light.
+ */
+vec3 specular(vec3 specularColor, vec3 h, vec3 v, vec3 l, float a, float NdL,
+              float NdV, float NdH, float VdH, float LdV) {
+  return (specularDistribution(a, NdH) *
+          specularGeometricAttenuation(a, NdV, NdL, NdH, VdH, LdV) *
+          specularFresnel(specularColor, v, h)) / (4.0 * NdL * NdV + 0.0001);
 }
 
-//---------- BRDF terms ------------//
-float Specular_D(float a, float NdH) {
-  return NormalDistribution_GGX(a, NdH);
-}
-
-vec3 Specular_F(vec3 specularColor, vec3 h, vec3 v) {
-  return Fresnel_Schlick(specularColor, h, v);
-}
-
-vec3 Specular_F_Roughness(vec3 specularColor, float a, vec3 h, vec3 v) {
-  return (specularColor + (max(vec3(1.0 - a), specularColor) - specularColor) * pow((1.0 - clamp(dot(v, h), 0.0, 1.0)), 5.0));
-}
-
-float Specular_G(float a, float NdV, float NdL, float NdH, float VdH, float LdV) {
-  return Geometric_Smith_Schlick_GGX(a, NdV, NdL);
-}
-
-vec3 Specular(vec3 specularColor, vec3 h, vec3 v, vec3 l, float a, float NdL, float NdV, float NdH, float VdH, float LdV) {
-  return ((Specular_D(a, NdH) * Specular_G(a, NdV, NdL, NdH, VdH, LdV)) * Specular_F(specularColor, v, h) ) / (4.0 * NdL * NdV + 0.0001);
-}
-
-vec3 ComputeLight(vec3 albedoColor,vec3 specularColor, vec3 normal, vec3 lightPosition, vec3 lightColor, vec3 lightDir, vec3 viewDir) {
-  // Compute some useful values.
+/*
+ * Computes total contribution of a light.
+ */
+vec3 computeLight(vec3 albedoColor, vec3 specularColor, vec3 normal,
+                  vec3 lightPosition, vec3 lightColor, vec3 lightDir,
+                  vec3 viewDir) {
   float NdL = clamp(dot(normal, lightDir), 0.0, 1.0);
-  float NdV = clamp(dot(normal, viewDir), 0.0, 1.0);
+
+  // FIXME: originally clamping at 0.0 to 1.0. Temporarily changed to 0.1 to
+  // fix shader quirks. 0.0 sounds mathematically correct so find the real
+  // cause of the quirks. Quirks include spheres not lit from the back and
+  // faces of cubes change color when the viewDir crosses a certain angle.
+  float NdV = clamp(dot(normal, viewDir), 0.1, 1.0);
+
   vec3 h = normalize(lightDir + viewDir);
   float NdH = clamp(dot(normal, h), 0.0, 1.0);
   float VdH = clamp(dot(viewDir, h), 0.0, 1.0);
   float LdV = clamp(dot(lightDir, viewDir), 0.0, 1.0);
   float a = max(0.001, roughness * roughness);
 
-  vec3 cDiff = Diffuse(albedoColor);
-  vec3 cSpec = Specular(specularColor, h, viewDir, lightDir, a, NdL, NdV, NdH, VdH, LdV);
+  vec3 cDiffuse = diffuse(albedoColor);
+  vec3 cSpec = specular(specularColor, h, viewDir, lightDir, a, NdL, NdV, NdH,
+                        VdH, LdV);
 
-  return lightColor * NdL * (cDiff * (1.0 - cSpec) + cSpec);
+  return lightColor * NdL * (cDiffuse * (1.0 - cSpec) + cSpec);
 }
 
-// Ok, this is ugly, but there is an explanation ...
-// WebGL need the extension EXT_shader_texture_lod in order to use textureCubeLod, and it's not yet implemented.
-// With textureCube the mipmap is automatically applied, and you can only add a bias.
-// To avoid that I saved each mip level in a separate cubemap.
-// If there is a less awfull way to do this I'd be happy to know !
-vec3 ComputeEnvColor(float roughness, vec3 reflectionVector) {
+/*
+  Explanation of cubemaps:
+  WebGL needs extension EXT_shader_texture_lod to use textureCubeLod,
+  but it's not yet implemented.
+  With textureCube the mipmap is auto-applied, and you can only add a bias.
+  To avoid that, we saved each mip level in a separate cubemap.
+  If there is a less awful way to do this, we'd be happy to know!
+*/
+vec3 computeEnvColor(float roughness, vec3 reflectionVector) {
+  // The higher the roughness, the lower the resolution mipmap to apply.
   float a = roughness * roughness * 6.0;
-  if ( a < 1.0) {
-    return mix(textureCube(envMap0, reflectionVector).rgb, textureCube(envMap1, reflectionVector).rgb, a);
-  }
 
-  if ( a < 2.0) {
-    return mix(textureCube(envMap1, reflectionVector).rgb, textureCube(envMap2, reflectionVector).rgb, a - 1.0);
+  if (a < 1.0) {
+    return mix(textureCube(envMap0, reflectionVector).rgb,
+               textureCube(envMap1, reflectionVector).rgb, a);
   }
-
-  if ( a < 3.0) {
-    return mix(textureCube(envMap2, reflectionVector).rgb, textureCube(envMap3, reflectionVector).rgb, a - 2.0);
+  if (a < 2.0) {
+    return mix(textureCube(envMap1, reflectionVector).rgb,
+               textureCube(envMap2, reflectionVector).rgb, a - 1.0);
   }
-
-  if ( a < 4.0) {
-    return mix(textureCube(envMap3, reflectionVector).rgb, textureCube(envMap4, reflectionVector).rgb, a - 3.0);
+  if (a < 3.0) {
+    return mix(textureCube(envMap2, reflectionVector).rgb,
+               textureCube(envMap3, reflectionVector).rgb, a - 2.0);
   }
-
-  if ( a < 5.0) {
-    return mix(textureCube(envMap4, reflectionVector).rgb, textureCube(envMap5, reflectionVector).rgb, a - 4.0);
+  if (a < 4.0) {
+    return mix(textureCube(envMap3, reflectionVector).rgb,
+               textureCube(envMap4, reflectionVector).rgb, a - 3.0);
   }
-
+  if (a < 5.0) {
+    return mix(textureCube(envMap4, reflectionVector).rgb,
+               textureCube(envMap5, reflectionVector).rgb, a - 4.0);
+  }
   return textureCube(envMap5, reflectionVector).rgb;
 }
 
 void main() {
   vec3 normal = vTestNormal;
 
+  // viewDir: vector pointing from vertex to camera.
   vec3 viewDir = normalize(cameraPosition - vPosition);
+
   vec3 albedoCorrected = pow(abs(baseColor.rgb), vec3(2.2));
 
   vec3 realAlbedo = baseColor - baseColor * metallic;
   vec3 realSpecularColor = mix(vec3(0.03, 0.03, 0.03), baseColor, metallic);
 
-  vec3 light1 = ComputeLight( realAlbedo, realSpecularColor, normal, vLightVector, vec3(0.4, 0.42, 0.37), vLightVector, viewDir);
-
   vec3 reflectVector = reflect(-viewDir, normal);
-  vec3 envColor = ComputeEnvColor(roughness, reflectVector);
 
-  vec3 envFresnel = Specular_F_Roughness(realSpecularColor, roughness * roughness, normal, viewDir);
+  vec3 envColor = computeEnvColor(roughness, reflectVector);
+  vec3 envFresnel = specularFresnelRoughness(realSpecularColor,
+                                             roughness * roughness, normal,
+                                             viewDir);
 
-  gl_FragColor = vec4(vec3(lightIntensity) * light1 + 1.0 * envFresnel * envColor + realAlbedo * 0.01, 1.0);
+  // Sum the lights.
+  vec3 totalLighting = vec3(0.0);
+  for (int i = 0; i < {{lightArraySize}}; i++) {
+    totalLighting += (
+      vec3(lightIntensities[i]) *
+      computeLight(realAlbedo, realSpecularColor, normal, lightPositions[i],
+                   lightColors[i], normalize(lightDirections[i]), viewDir)
+    );
+  }
+
+  gl_FragColor = vec4(totalLighting + 1.0 * envFresnel * envColor +
+                      realAlbedo * 0.01, 1.0);
 }

--- a/src/shaders/pbrVertex.glsl
+++ b/src/shaders/pbrVertex.glsl
@@ -7,21 +7,16 @@ uniform vec2 uvScale;
 
 varying vec2 vUv;
 varying mat3 tbn;
-varying vec3 vLightVector;
-varying vec3 vTestNormal;
 varying vec3 vPosition;
+varying vec3 vTestNormal;
 
 void main() {
-  vUv = uvScale * uv;
-
   vec3 vNormal = normalize(normalMatrix * normal);
   vec3 vTangent = normalize(normalMatrix * tangent.xyz);
   vec3 vBinormal = normalize(cross(vNormal, vTangent) * tangent.w);
 
+  vUv = uvScale * uv;
   tbn = mat3(vTangent, vBinormal, vNormal);
-
-  vLightVector = normalize(vec3(0.4, 0.2 ,0.2));
-
   vPosition = position;
   vTestNormal = normal;
 


### PR DESCRIPTION
**Notes:**
- add light component that registers itself to the scene element
- have scene element handle updating of all material parameters/uniforms whenever a light is modified or added
- modify material component to register itself to the scene so it can subscribe to light updates, and pass scene lights into the pbr shaders through the uniforms
- use browserify-shader to allow directly requiring and parameterizing .glsl files
- un-hardcode and allow multiple lights in the pbr shaders
- clean up pbr shaders (unused vars, 80 chars, readability)
- add tons of comments to the shaders, sweep to make sure it matches the theoretical lighting models, fix shader quirks
- use a different style parser that works
- fixed shader quirks by not allowing the half vector to be 0...probably not the correct way, view the FIXME
- add default directional light to scene

**TODO:**
- improve perf when animating the light by providing more granular updates
- add a small hard-coded ambient light
- support for point and ambient light types
