### PR TITLE
do not warn when foreign attributes ("components") are being used

### DIFF
--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -132,10 +132,7 @@ var proto = {
   updateComponent: {
     value: function (name) {
       var component = VRComponents[name];
-      if (!component) {
-        VRUtils.warn('Unkown component name: ' + name);
-        return;
-      }
+      if (!component) { return; }
       this.components[name].updateAttributes(this.getAttribute(name));
     },
     writable: window.debug


### PR DESCRIPTION
if you specify some HTML5 standard attribute (such as `title`), a console warning gets thrown:

> `Unknown component name: title`

Or this:

> `Unknown component name: onclick`

I understand why we have this in the first place, but we should perhaps have a whitelist for all the "known" HTML standard attributes.
