### PR TITLE
change style parser to something more simple/working (#230)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "main": "src/vr-markup.js",
   "dependencies": {
     "document-register-element": "^0.4.5",
-    "parse-css": "git://github.com/tabatkins/parse-css.git#0d442e04bd4bc6c",
     "request-interval": "^1.0.0",
+    "style-attr": "^1.0.1",
     "three": "^0.72.0",
     "tween.js": "^15.0.0"
   },

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -1,27 +1,13 @@
-var cssParser = require('parse-css');
+var styleParser = require('style-attr');
 var mixin = require('../vr-utils').mixin;
-
-/**
- * The CSS parser returns the attributes
- * in a nested object. We flatten the structure
- * into flat key value pairs
- */
-var flattenAttributes = function (attrs) {
-  var obj = {};
-  attrs.forEach(flatten);
-  function flatten (attr) {
-    obj[attr.name] = attr.value[1].value;
-  }
-  return obj;
-};
 
 var mixAttributes = function (str, obj) {
   var attrs = str;
   if (!str) { return; }
-  // The attributes can come in the form of a string or already pre parsed in an object
-  // like rotation, position and scale
+  // Attributes can come in the form of a string or pre-parsed as an object
+  // such as pos/rot/scale.
   if (typeof str === 'string') {
-    attrs = flattenAttributes(cssParser.parseAListOfDeclarations(str));
+    attrs = styleParser.parse(str);
   }
   mixin(obj, attrs);
 };


### PR DESCRIPTION
`parse-css` was having unexpected results since it seems to be more for parsing stylesheets than style attributes. It was stripping hashes and whitespace when we didn't want it to. This switches to use `style-attr` which works as expected.
