### PR TITLE
support for ambient lights for light component

### DIFF
--- a/examples/lights/index.html
+++ b/examples/lights/index.html
@@ -19,9 +19,17 @@
     <vr-object position="0 0 20" camera="fov: 45"
                controls="mouselook: true; locomotion: true"></vr-object>
 
-    <vr-object light="color: #CCCCFF; intensity: 15"
-               position="-10 10 10" rotation="-0.2 0.2 0.2">
+    <!-- Ambient light. -->
+    <vr-object light="type: ambient; color: #222"></vr-object>
+
+    <!-- Animating directional light. -->
+    <vr-object light="color: #EEEEEE; intensity: 5" rotation="-0.2 0.2 0.2">
       <vr-animation mixin="orbit"></vr-animation>
+    </vr-object>
+
+    <!-- Fixed directional light. -->
+    <vr-object light="color: #EEEEEE; intensity: 2.5"
+               position="-10 10 10" rotation="-0.2 0 0.2">
     </vr-object>
 
     <!-- Lit objects. -->
@@ -32,7 +40,7 @@
     <vr-object position="0 0 0" rotation="0 45 0" geometry="primitive: box"
                material="color: green; metallic: .8"></vr-object>
     <vr-object position="10 0 0" rotation="0 0 45" geometry="primitive: box"
-               material="color: blue; roughness: 1; metallic: 0"></vr-object>
+               material="color: blue; roughness: 1; metallic: .5"></vr-object>
   </vr-scene>
 </body>
 </html>

--- a/src/components/light.js
+++ b/src/components/light.js
@@ -15,14 +15,16 @@ var id = 1;
  * To support PBR, currently not using three.js lights. PBR materials are not
  * yet officially implemented by three.js.
  *
- * @param {string} color - light color.
+ * @param {string} color - light base color.
  * @param {number} intensity - light strength.
+ * @param {string} type - light type (e.g., directional, ambient).
  */
 module.exports.Component = registerComponent('light', {
   defaults: {
     value: {
-      color: '#ffffff',
-      intensity: 1.0
+      color: '#FFFFFF',
+      intensity: 1.0,
+      type: 'directional'
     }
   },
 
@@ -42,13 +44,15 @@ module.exports.Component = registerComponent('light', {
    */
   update: {
     value: function () {
-      if (!this.data) { return; }
+      var data = this.data;
+      if (!data) { return; }
 
-      var color = new THREE.Color(this.data.color);
+      var color = new THREE.Color(data.color);
       this.el.registerLight({
         id: this.id,
         color: new THREE.Vector3(color.r, color.g, color.b),
-        intensity: this.data.intensity
+        intensity: data.intensity,
+        type: data.type
       });
     }
   }

--- a/src/core/vr-scene.js
+++ b/src/core/vr-scene.js
@@ -13,15 +13,21 @@ var VRScene = module.exports = registerElement(
       VRNode.prototype, {
         defaults: {
           value: {
-            lights: {
-              // Default directional light.
-              0: {
+            lights: [
+              {
+                // Default directional light.
                 color: new THREE.Vector3(1.0, 1.0, 1.0),
                 direction: new THREE.Vector3(-0.5, 1.0, 0.5),
+                intensity: 2.0,
                 position: new THREE.Vector3(0, 0, 0),
-                intensity: 5.0
+                type: 'directional'
+              },
+              {
+                // Default global ambient light.
+                color: new THREE.Vector3(0.2, 0.2, 0.2),
+                type: 'ambient'
               }
-            }
+            ]
           }
         },
 

--- a/src/shaders/pbrFragment.glsl
+++ b/src/shaders/pbrFragment.glsl
@@ -18,7 +18,6 @@
  * @param roughness (float)
  *
  * Currently supports directional light.
- * TODO: add support and defaults for ambient lighting.
  * TODO: add support for point light, light positions are present but unused.
  *
  * Originally adapted from: alexandre-pestana.com/webgl/PBRViewer.html
@@ -36,6 +35,7 @@ uniform samplerCube envMap2;
 uniform samplerCube envMap3;
 uniform samplerCube envMap4;
 uniform samplerCube envMap5;
+uniform vec3 ambientLight;
 uniform vec3 lightColors[{{lightArraySize}}];
 uniform vec3 lightDirections[{{lightArraySize}}];
 uniform int lightIntensities[{{lightArraySize}}];
@@ -192,7 +192,7 @@ void main() {
                                              viewDir);
 
   // Sum the lights.
-  vec3 totalLighting = vec3(0.0);
+  vec3 totalLighting = ambientLight;
   for (int i = 0; i < {{lightArraySize}}; i++) {
     totalLighting += (
       vec3(lightIntensities[i]) *


### PR DESCRIPTION
- support (diffuse) ambient light (`light: type: ambient; color: 'anycolor'`)
- default ambient light for scene is dark gray. if the user adds any light, the default directional + default ambient are both deactivated.
- in material.js, pre-calculate the ambient light and hand to the shader. 
- in material.js, separate ambient vs. directed lights. only recompile shader if number of _directed_ lights changes.

![ambient](https://cloud.githubusercontent.com/assets/674727/10591284/3dbf26ec-766a-11e5-8f8a-252b91af6949.gif)
