### PR TITLE
Components that have default values won't reflect those values on the…

### DIFF
--- a/src/core/component.js
+++ b/src/core/component.js
@@ -1,3 +1,4 @@
+/* global HTMLElement */
 var styleParser = require('style-attr');
 var utils = require('../vr-utils');
 
@@ -26,9 +27,9 @@ Component.prototype = {
    * Parses the data coming from the entity attribute
    * and its mixins and calls update
    */
-  updateAttributes: function (values) {
+  updateAttributes: function () {
     var previousData = utils.mixin({}, this.data);
-    this.parseAttributes(values);
+    this.parseAttributes();
     // Don't update if properties haven't changed
     if (utils.deepEqual(previousData, this.data)) { return; }
     this.update();
@@ -59,10 +60,11 @@ Component.prototype = {
    *  @param  {object} [attrs] It contains the attribute values
    *  @return {undefined}
    */
-  parseAttributes: function (attrs) {
+  parseAttributes: function () {
     var data = {};
     var el = this.el;
-    var elAttrs = attrs || el.getAttribute(this.name);
+    var unparsedAttrs = HTMLElement.prototype.getAttribute.call(el, this.name);
+    var elAttrs = unparsedAttrs === '' ? {} : el.getAttribute(this.name);
     var self = this;
     var mixinEls = el.mixinEls;
     // Copy the default first. Lowest precedence

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -14,12 +14,11 @@ var VRUtils = require('../vr-utils');
  */
 var proto = {
 
-  // Default Attribute Values
   defaults: {
     value: {
-      position: '0 0 0',
-      rotation: '0 0 0',
-      scale: '1 1 1'
+      position: '',
+      rotation: '',
+      scale: ''
     }
   },
 
@@ -214,7 +213,6 @@ var proto = {
 
   initComponent: {
     value: function (name, attrs) {
-      var defaults = this.defaults;
       var hasAttribute = this.hasAttribute(name);
       // If it's not a component name or
       // If the component is already initialized
@@ -225,8 +223,8 @@ var proto = {
       this.components[name] = new VRComponents[name].Component(this);
       // If the attribute is not defined but has a default we set it
       if (!hasAttribute) {
-        attrs = defaults[name] ? defaults[name] : attrs;
-        if (attrs !== undefined) { this.setAttribute(name, attrs); }
+        attrs = attrs !== undefined ? attrs : '';
+        this.setAttribute(name, attrs);
       }
       VRUtils.log('Component initialized: %s', name);
     }


### PR DESCRIPTION
… element attribute. e.g: rotation, scale and position will default to <vr-object position="" scale="" rotation=""></vr-object>. We can now use mixins that apply positions, rotations and scales. Not showing the default in the attributes is consistent with the rest of the components. If we do <vr-object cursor></vr-object> the fuse attribute of the component defaults to 'false' and is not shown on the element.
