### PR TITLE
Add thetalength and thetastart values to cylinders

### DIFF
--- a/examples/cylinders/index.html
+++ b/examples/cylinders/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Cylinders</title>
+    <meta name="description" content="Cylinders — vr-markup">
+    <link rel="stylesheet" type="text/css" href="../../style/vr-markup.css">
+    <link rel="stylesheet" type="text/css" href="../_style/main.css">
+    <script src="../../build/vr-markup.js"></script>
+  </head>
+  <body>
+    <vr-scene stats="true">
+      <vr-object position="0 0 20" camera="fov: 45" controls="mouselook: true; locomotion: true"></vr-object>
+      <vr-object position="-10 0 0" rotation="45 0 -45" geometry="primitive: cylinder; radius: 2; height: 5; openEnded: false;" material="color: aqua"></vr-object>
+      <vr-object position="0 0 0" rotation="25 0 10" geometry="primitive: cylinder; radius: 4; height: 2; openEnded: true;" material="color: crimson"></vr-object>
+      <vr-object position="10 0 0" rotation="75 0 0" geometry="primitive: cylinder; radius: 2; height: 4; openEnded: false; thetaLength: 4.5" material="color: gold"></vr-object>
+       <vr-object position="0 4 0" rotation="0 0 0" geometry="primitive: cylinder; radius: 4; height: 2; openEnded: true; thetaLength: 3; thetaStart: 3" material="color: orchid"></vr-object>
+    </vr-scene>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -43,6 +43,7 @@
       <li><a href="animation/">Animation</a></li>
       <li><a href="cursor/">Cursor</a></li>
       <li><a href="cubes/">Cubes</a></li>
+      <li><a href="cylinders/">Cylinders</a></li>
       <li><a href="lights/">Lights</a></li>
       <li><a href="mixin/">Mixin</a></li>
       <li><a href="texture/">Texture</a></li>

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -14,9 +14,11 @@ module.exports.Component = registerComponent('geometry', {
       segmentsWidth: 36,
       segmentsHeight: 18,
       segmentsRadius: 36,
+      thetaStart: 0,
+      thetaLength: 6.3,
       innerRadius: 5,
       outerRadius: 7,
-      openEnded: true
+      openEnded: false
     }
   },
 
@@ -42,10 +44,10 @@ module.exports.Component = registerComponent('geometry', {
           geometry = new THREE.BoxGeometry(data.width, data.height, data.depth);
           break;
         case 'circle':
-          geometry = new THREE.CircleGeometry(data.radius, data.segments);
+          geometry = new THREE.CircleGeometry(data.radius, data.segments, data.thetaStart, data.thetaLength);
           break;
         case 'cylinder':
-          geometry = new THREE.CylinderGeometry(data.radius, data.radius, data.height, data.segmentsRadius, data.segmentsHeight, data.openEnded);
+          geometry = new THREE.CylinderGeometry(data.radius, data.radius, data.height, data.segmentsRadius, data.segmentsHeight, data.openEnded, data.thetaStart, data.thetaLength);
           break;
         case 'plane':
           geometry = new THREE.PlaneBufferGeometry(data.width, data.height);

--- a/src/vr-utils.js
+++ b/src/vr-utils.js
@@ -112,4 +112,3 @@ module.exports.deepEqual = function (a, b) {
   }
   return true;
 };
-


### PR DESCRIPTION
Curved planes are very important for VR layouts. This PR adds thetaStart and thetaLength to cylinders in the geometry component. When combined with `openEnded: true` this enables users to create curved planes.

Also added the values to CircleGeometry, since it also uses thetaStart and thetaLength.
