### PR TITLE
Small refactor on how components and attribute values map to one anot…

### DIFF
--- a/examples/cursor/index.html
+++ b/examples/cursor/index.html
@@ -25,13 +25,13 @@
         <vr-object position="0 0 -5" geometry="primitive: ring; outerRadius: 0.30; innerRadius: 0.20;" material="color: red" cursor="maxDistance: 30"></vr-object>
       </vr-object>
 
-      <vr-object position="-10 0 0" rotation="0 0 0">
+      <vr-object position="-10 0 0">
         <vr-object mixin="cube red">
           <vr-animation begin="click" attribute="position" from="0 0 0" to="0 0 -10" dur="2000" fill="both"></vr-animation>
         </vr-object>
       </vr-object>
 
-      <vr-object position="0 0 0" rotation="0 0 0">
+      <vr-object>
         <vr-object mixin="cube green">
           <vr-animation begin="click" attribute="rotation" to="0 360 0" easing="linear" dur="2000"></vr-animation>
         </vr-object>

--- a/examples/mixin/index.html
+++ b/examples/mixin/index.html
@@ -10,15 +10,15 @@
   </head>
   <body>
     <vr-assets>
-      <vr-mixin id="cube" geometry="primitive: box" material="color: red"></vr-mixin>
+      <vr-mixin id="cube" geometry="primitive: box" material="color: red" rotation="0 45 0"></vr-mixin>
       <vr-mixin id="sphere" geometry="primitive: sphere" material="color: blue"></vr-mixin>
     </vr-assets>
     <vr-scene stats="true">
       <vr-object position="0 0 20" camera="fov: 45" controls="mouselook: true; locomotion: true"></vr-object>
       <!-- specialization of a particular component with an applied mixin -->
-      <vr-object mixin="cube" position="-10 0 0" rotation="0 45 0" material="color: yellow"></vr-object>
-      <vr-object mixin="cube" position="0 0 0" rotation="0 45 0"></vr-object>
-      <vr-object mixin="cube" position="10 0 0" rotation="0 45 0"></vr-object>
+      <vr-object mixin="cube" position="-10 0 0"material="color: yellow"></vr-object>
+      <vr-object mixin="cube"></vr-object>
+      <vr-object mixin="cube" position="10 0 0"></vr-object>
     </vr-scene>
   </body>
 </html>

--- a/src/components/controls.js
+++ b/src/components/controls.js
@@ -63,8 +63,8 @@ module.exports.Component = registerComponent('controls', {
       velocity.x -= velocity.x * 10.0 * delta;
       velocity.z -= velocity.z * 10.0 * delta;
 
-      var position = el.getAttribute('position');
-      var rotation = el.getAttribute('rotation');
+      var position = el.getComputedAttribute('position');
+      var rotation = el.getComputedAttribute('rotation');
       var rotZ = rotation.z;
 
       if (this.data.locomotion === 'true') {

--- a/src/components/visible.js
+++ b/src/components/visible.js
@@ -2,27 +2,25 @@ var registerComponent = require('../core/register-component').registerComponent;
 
 var proto = {
   defaults: {
-    value: {
-      visible: true
-    }
+    value: true
   },
 
   update: {
     value: function () {
       var object3D = this.el.object3D;
-      object3D.visible = this.data.visible;
+      object3D.visible = this.data;
     }
   },
 
   parseAttributesString: {
     value: function (attrs) {
-      return { visible: attrs === 'true' };
+      return attrs === 'true';
     }
   },
 
   stringifyAttributes: {
     value: function (attrs) {
-      return attrs.visible.toString();
+      return attrs.toString();
     }
   }
 };

--- a/src/core/vr-animation.js
+++ b/src/core/vr-animation.js
@@ -121,7 +121,7 @@ module.exports = registerElement(
             var repeat = data.repeat === 'indefinite' ? Infinity : 0;
             var el = this.el;
             var attribute = data.attribute;
-            var current = el.getAttribute(attribute);
+            var current = el.getComputedAttribute(attribute);
             var from = data.from ? utils.parseCoordinate(data.from) : current;
             var tween = this.tween;
             var begin = parseInt(data.begin, 10);
@@ -250,7 +250,7 @@ module.exports = registerElement(
             Object.keys(defaults).forEach(copyAttribute);
             function copyAttribute (key) {
               if (el.hasAttribute(key)) {
-                data[key] = el.getAttribute(key, defaults[key]);
+                data[key] = el.getAttribute(key);
               }
             }
             return data;

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -226,7 +226,6 @@ var proto = {
 
   initComponent: {
     value: function (name, attrs) {
-      var hasAttribute = this.hasAttribute(name);
       // If it's not a component name or
       // If the component is already initialized
       if (!VRComponents[name] || this.components[name]) { return; }
@@ -234,11 +233,6 @@ var proto = {
       if (!this.isComponentDefined(name) && attrs === undefined) { return; }
       this.initComponentDependencies(name);
       this.components[name] = new VRComponents[name].Component(this);
-      // If the attribute is not defined but has a default we set it
-      if (!hasAttribute) {
-        attrs = attrs !== undefined ? attrs : '';
-        this.setAttribute(name, attrs);
-      }
       VRUtils.log('Component initialized: %s', name);
     }
   },
@@ -253,7 +247,7 @@ var proto = {
       dependencies = VRComponents[name].dependencies;
       if (!dependencies) { return; }
       Object.keys(dependencies).forEach(function (key) {
-        self.initComponent(key, dependencies[key]);
+        self.setAttribute(key, dependencies[key]);
       });
     }
   },
@@ -298,6 +292,20 @@ var proto = {
       var value = HTMLElement.prototype.getAttribute.call(this, attr);
       if (!component || typeof value !== 'string') { return value; }
       return component.parseAttributesString(value);
+    },
+    writable: window.debug
+  },
+
+  /**
+   * Returns the computed attribute from the element itself,
+   * applied mixins and default values
+   * @type {string} attribe name
+   */
+  getComputedAttribute: {
+    value: function (attr) {
+      var component = this.components[attr];
+      if (component) { return component.getData(); }
+      return HTMLElement.prototype.getAttribute.call(this, attr);
     },
     writable: window.debug
   },


### PR DESCRIPTION
…her. If a component just has default values the corresponding attribute won't be set. Adds getComputedAttribute to vr-object to get the computed value from the element, mixins and default values. Primitive values like the visible component get returned as a simple value when calling getAttribute('visible'). Before we were returning an object { visible: true }.
