### PR TITLE
require webvr-polyfill after three.js

### DIFF
--- a/src/vr-markup.js
+++ b/src/vr-markup.js
@@ -1,5 +1,3 @@
-require('webvr-polyfill');
-
 var registerElement = require('./vr-register-element');
 
 var VRObject = require('./core/vr-object');
@@ -9,6 +7,7 @@ var VRNode = require('./core/vr-node');
 // use three.js without alteration
 var THREE = window.THREE = require('../lib/three');
 var VRUtils = require('./vr-utils');
+require('webvr-polyfill');
 
 require('./core/vr-animation');
 require('./core/vr-assets');


### PR DESCRIPTION
webvr-polyfill checks window.THREE and starts polyfilling three.js math stuff if it doesn't detect. it will also throw a "THREE not found" message in the console.
