### PR TITLE
faster GitHub Pages deploys (fixes #390)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cache
 .DS_Store
 build
 gh-pages/

--- a/scripts/gh-pages.js
+++ b/scripts/gh-pages.js
@@ -49,8 +49,19 @@ repo.ghPagesUrl = 'https://' + repo.username + '.github.io/' + repo.name + '/';
 
 console.log('Publishing to', repo.url);
 
-ghpages.clean();  // Wipe out the checkout from scratch every time in case we change repos.
+function getCacheDir (repoUsername, repoName) {
+  repoUsername = (repoUsername || '').toLowerCase().trim();
+  repoName = (repoName || '').toLowerCase().trim();
+  var pathAbsolute = path.resolve(
+    __dirname,
+    '..',
+    '.cache', 'gh-pages', repoUsername, repoName
+  );
+  return path.relative(process.cwd(), pathAbsolute);
+}
+
 ghpages.publish(path.join(process.cwd(), 'gh-pages'), {
+  clone: getCacheDir(repo.username, repo.name),
   repo: repo.url,
   dotfiles: true,
   logger: function (message) {


### PR DESCRIPTION
I'm in the process of publishing the [GitHub™ Pages deploy script](https://github.com/MozVR/aframe-core/blob/dev/scripts/gh-pages.js) as a third-party thing, but for now this shall suffice.

Nearly **`10 seconds`** (`9.792`) faster! :+1: 
## before

12.566 seconds
<img width="938" alt="screenshot 2015-11-09 18 59 45" src="https://cloud.githubusercontent.com/assets/203725/11053240/38ed9b20-8714-11e5-8068-4d9ee72f5c98.png">
## after

2.774 seconds
<img width="938" alt="screenshot 2015-11-09 18 59 27" src="https://cloud.githubusercontent.com/assets/203725/11053239/38ed1470-8714-11e5-9be7-826ede72bf60.png">
