### PR TITLE
fix cursor for visibility example

### DIFF
--- a/examples/visibility/index.html
+++ b/examples/visibility/index.html
@@ -21,8 +21,14 @@
     </vr-assets>
 
     <vr-scene stats="true">
-      <vr-object position="0 0 20" camera="fov: 45" controls="mouselook: true; locomotion: true">
-        <vr-object position="0 0 -5" geometry="primitive: ring; outerRadius: 0.30; innerRadius: 0.20;" material="color: red" cursor="maxDistance: 30"></vr-object>
+      <vr-object position="0 0 20" mouse-controls keyboard-controls>
+        <vr-object camera="fov: 45" hmd-controls>
+          <vr-object position="0 0 -5"
+                     geometry="primitive: ring; outerRadius: 0.30;
+                               innerRadius: 0.20"
+                     material="color: red; receiveLight: false"
+                     cursor="maxDistance: 30"></vr-object>
+        </vr-object>
       </vr-object>
 
       <vr-object id="blueCube"


### PR DESCRIPTION
it looks like PR #379 updated the camera conventions and the visibility PR (#344) wasn't updated as such. so this fixes that.
