### PR TITLE
add setComponentAttribute (fixes #235)

### DIFF
--- a/examples/visibility/index.html
+++ b/examples/visibility/index.html
@@ -69,14 +69,14 @@
               redSphere.setAttribute('visible', false);
               break;
             case greenCylinder:
-              var oldVisible = greenCylinder.getComputedAttribute('visible');
+              var oldVisible = greenCylinder.getComponentData('visible');
               // See issue: https://github.com/MozVR/aframe-core/issues/349
               if (oldVisible === null) { oldVisible = true; }
               greenCylinder.setAttribute('visible', !oldVisible);
               break;
             case pinkTorus:
               // Yes, this is gross. See https://github.com/MozVR/aframe-core/issues/235
-              var oldMaterial = pinkTorus.getComputedAttribute('material');
+              var oldMaterial = pinkTorus.getComponentData('material');
               var oldOpacity = oldMaterial.opacity;
               var newOpacity = oldOpacity === 1 ? 0 : 1;
               var newMaterial = oldMaterial;

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -45,7 +45,7 @@ module.exports.Component = registerComponent('wasd-controls', {
       velocity.x -= velocity.x * easing * delta;
       velocity.z -= velocity.z * easing * delta;
 
-      var position = el.getComputedAttribute('position');
+      var position = el.getComponentData('position');
 
       if (this.data.enabled) {
         if (keys[65]) { velocity.x -= acceleration * delta; } // Left

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -115,8 +115,9 @@ Component.prototype = {
   },
 
   /**
-   * Calls style parser on a component string.
-   * camelCases keys for error-tolerance (`max-value` ~= `maxValue`).
+   * Deserializes component data from string to object.
+   * Also camelCases keys for error-tolerance (`max-value` ~= `maxValue`).
+   * Can be overridden by components.
    *
    * @returns {object}
    */
@@ -125,6 +126,12 @@ Component.prototype = {
     return transformKeysToCamelCase(styleParser.parse(attrs));
   },
 
+  /**
+   * Serializes component data from object to string.
+   * Can be overridden by components.
+   *
+   * @returns {string}
+   */
   stringifyAttributes: function (attrs) {
     if (typeof attrs !== 'object') { return attrs; }
     return styleParser.stringify(attrs);

--- a/src/core/vr-animation.js
+++ b/src/core/vr-animation.js
@@ -148,7 +148,7 @@ module.exports = registerElement('vr-animation', {
 
         var attribute = data.attribute;
         var begin = parseInt(data.begin, 10);
-        var currentValue = el.getComputedAttribute(attribute);
+        var currentValue = el.getComponentData(attribute);
         var direction = this.getDirection(data.direction);
         var easing = EASING_FUNCTIONS[data.easing];
         var fill = data.fill;

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -42,8 +42,7 @@ var proto = {
     value: function () {
       this.addToParent();
       this.load();
-    },
-    writable: window.debug
+    }
   },
 
   /**
@@ -75,16 +74,14 @@ var proto = {
         return;
       }
       this.updateComponent(attr, oldVal, newVal);
-    },
-    writable: window.debug
+    }
   },
 
   detachedCallback: {
     value: function () {
       if (!this.parentEl) { return; }
       this.parentEl.remove(this);
-    },
-    writable: window.debug
+    }
   },
 
   applyMixin: {
@@ -94,8 +91,7 @@ var proto = {
         return;
       }
       this.updateComponent(attr);
-    },
-    writable: window.debug
+    }
   },
 
   mapStateMixins: {
@@ -109,8 +105,7 @@ var proto = {
         op(mixinId);
       });
       this.updateComponents();
-    },
-    writable: window.debug
+    }
   },
 
   updateStateMixins: {
@@ -135,8 +130,7 @@ var proto = {
           self.registerMixin(mixinId);
         });
       });
-    },
-    writable: window.debug
+    }
   },
 
   add: {
@@ -145,8 +139,7 @@ var proto = {
         VRUtils.error("Trying to add an object3D that doesn't exist");
       }
       this.object3D.add(el.object3D);
-    },
-    writable: window.debug
+    }
   },
 
   addToParent: {
@@ -168,8 +161,7 @@ var proto = {
         self.attachedToParent = true;
         parent.add(self);
       }
-    },
-    writable: window.debug
+    }
   },
 
   load: {
@@ -195,8 +187,7 @@ var proto = {
   remove: {
     value: function (el) {
       this.object3D.remove(el.object3D);
-    },
-    writable: window.debug
+    }
   },
 
   initComponents: {
@@ -206,8 +197,7 @@ var proto = {
       keys.forEach(function (key) {
         self.initComponent(key);
       });
-    },
-    writable: window.debug
+    }
   },
 
   /**
@@ -268,8 +258,7 @@ var proto = {
       var components = Object.keys(this.components);
       // Updates components
       components.forEach(this.updateComponent.bind(this));
-    },
-    writable: window.debug
+    }
   },
 
   /**
@@ -298,8 +287,7 @@ var proto = {
       }
       // Component not yet initialized. Initialize component.
       this.initComponent(name);
-    },
-    writable: window.debug
+    }
   },
 
   setAttribute: {
@@ -309,8 +297,7 @@ var proto = {
         value = component.stringifyAttributes(value);
       }
       HTMLElement.prototype.setAttribute.call(this, attr, value);
-    },
-    writable: window.debug
+    }
   },
 
   /**
@@ -327,8 +314,24 @@ var proto = {
       var value = HTMLElement.prototype.getAttribute.call(this, attr);
       if (!component || typeof value !== 'string') { return value; }
       return component.parseAttributesString(value);
-    },
-    writable: window.debug
+    }
+  },
+
+  /**
+   *
+   * @param {string} componentName
+   * @param {string} attributeName
+   * @param defaultValue
+   * @returns Attribute value if it exists, else defaultValue, else null.
+   */
+  getComponentAttribute: {
+    value: function (componentName, attributeName, defaultValue) {
+      var componentData = this.getComponentData(componentName);
+      if (componentData) {
+        return componentData[attributeName] || defaultValue;
+      }
+      return defaultValue || null;
+    }
   },
 
   /**
@@ -336,15 +339,13 @@ var proto = {
    * mixins and defaults.
    *
    * @param {string} attr
-   * @returns {object|string} Object if component, else string.
+   * @returns {object} Object if component, else null.
    */
-  getComputedAttribute: {
-    value: function (attr) {
-      var component = this.components[attr];
+  getComponentData: {
+    value: function (componentName) {
+      var component = this.components[componentName];
       if (component) { return component.getData(); }
-      return HTMLElement.prototype.getAttribute.call(this, attr);
-    },
-    writable: window.debug
+    }
   },
 
   addState: {
@@ -353,8 +354,7 @@ var proto = {
       this.states.push(state);
       this.mapStateMixins(state, this.registerMixin.bind(this));
       this.emit('stateadded', {state: state});
-    },
-    writable: window.debug
+    }
   },
 
   removeState: {
@@ -364,8 +364,7 @@ var proto = {
       this.states.splice(stateIndex, 1);
       this.mapStateMixins(state, this.unregisterMixin.bind(this));
       this.emit('stateremoved', {state: state});
-    },
-    writable: window.debug
+    }
   },
 
   /**
@@ -379,8 +378,7 @@ var proto = {
         if (elState === state) { is = index; }
       });
       return is;
-    },
-    writable: window.debug
+    }
   }
 };
 

--- a/src/core/vr-object.js
+++ b/src/core/vr-object.js
@@ -301,6 +301,37 @@ var proto = {
   },
 
   /**
+   * Sets a component's attribute to a value.
+   * Does not do anything if value is the same as the current value.
+   * Done through the DOM to make sure all the appropriate attributeChangedCbs
+   * are called and things work as expected.
+   *
+   * @param {string} componentName
+   * @param {string} componentAttributeName
+   * @param value
+   */
+  setComponentAttribute: {
+    value: function (componentName, componentAttributeName, value) {
+      var component = this.components[componentName];
+      var currentVal;
+      var data;
+      if (!component) { return; }
+
+      data = component.getData();
+      currentVal = data[componentAttributeName];
+      if (currentVal === value) { return; }
+      if (currentVal.constructor !== value.constructor) {
+        VRUtils.warn(
+          'Calling setComponentAttribute using a value with an unexpected ' +
+          'type based on the component definition');
+      }
+
+      data[componentAttributeName] = value;
+      this.setAttribute(componentName, component.stringifyAttributes(data));
+    }
+  },
+
+  /**
    * If attribute is a component, it parses the style-like string into an
    * object. Returned component data does not include applied mixins or
    * defaults.
@@ -325,12 +356,9 @@ var proto = {
    * @returns Attribute value if it exists, else defaultValue, else null.
    */
   getComponentAttribute: {
-    value: function (componentName, attributeName, defaultValue) {
+    value: function (componentName, attributeName) {
       var componentData = this.getComponentData(componentName);
-      if (componentData) {
-        return componentData[attributeName] || defaultValue;
-      }
-      return defaultValue || null;
+      return componentData ? componentData[attributeName] : null;
     }
   },
 
@@ -343,8 +371,11 @@ var proto = {
    */
   getComponentData: {
     value: function (componentName) {
-      var component = this.components[componentName];
-      if (component) { return component.getData(); }
+      var component;
+      if (!componentName) { return null; }
+      component = this.components[componentName];
+      if (!component) { return; }
+      return component.getData();
     }
   },
 

--- a/tests/core/vr-object.test.js
+++ b/tests/core/vr-object.test.js
@@ -159,19 +159,54 @@ suite('vr-object', function () {
     });
   });
 
-  suite('getComputedAttribute', function () {
-    test('returns fully parsed component data', function (done) {
+  suite('getComponentAttribute', function () {
+    test('gets an attribute', function (done) {
+      var el = entityFactory();
+      el.setAttribute('geometry', 'primitive: box; width: 5');
+
+      el.addEventListener('loaded', function () {
+        process.nextTick(function () {
+          assert.equal(el.getComponentAttribute('geometry', 'primitive'),
+                       'box');
+          assert.equal(el.getComponentAttribute('geometry', 'width'), 5);
+          assert.ok(el.getComponentAttribute('geometry', 'height'));
+          done();
+        });
+      });
+    });
+
+    test('returns null if attribute not defined', function (done) {
+      var el = entityFactory();
+      el.addEventListener('loaded', function () {
+        assert.notOk(el.getComponentAttribute('geometry', 'color'));
+        done();
+      });
+    });
+  });
+
+  suite('getComponentData', function () {
+    test('returns full component data', function (done) {
       var componentData;
       var el = entityFactory();
       el.addEventListener('loaded', function () {
         el.setAttribute('geometry', 'primitive: box; width: 5');
         process.nextTick(function () {
-          componentData = el.getComputedAttribute('geometry');
+          componentData = el.getComponentData('geometry');
           assert.equal(componentData.primitive, 'box');
           assert.equal(componentData.width, 5);
           assert.ok('height' in componentData);
           done();
         });
+      });
+    });
+
+    test('returns null if not component', function (done) {
+      var componentData;
+      var el = entityFactory();
+      el.addEventListener('loaded', function () {
+        componentData = el.getComponentData('geometry');
+        assert.notOk(componentData);
+        done();
       });
     });
   });

--- a/tests/core/vr-object.test.js
+++ b/tests/core/vr-object.test.js
@@ -219,4 +219,44 @@ suite('vr-object', function () {
       assert.ok(el.outerHTML.indexOf('position="10 20 30"') !== -1);
     });
   });
+
+  suite('setComponentAttribute', function () {
+    test('sets component attribute that is implicitly set', function (done) {
+      var el = entityFactory();
+      el.setAttribute('light', 'type: ambient');
+      el.addEventListener('loaded', function () {
+        el.setComponentAttribute('light', 'color', '#F0F');
+        process.nextTick(function () {
+          assert.equal(el.getComponentData('light').type, 'ambient');
+          assert.equal(el.getComponentData('light').color, '#F0F');
+          done();
+        });
+      });
+    });
+
+    test('sets component attribute that is explicitly set', function (done) {
+      var el = entityFactory();
+      el.setAttribute('light', 'type: ambient; color: #FFF');
+      el.addEventListener('loaded', function () {
+        el.setComponentAttribute('light', 'color', '#F0F');
+        process.nextTick(function () {
+          assert.equal(el.getComponentData('light').type, 'ambient');
+          assert.equal(el.getComponentData('light').color, '#F0F');
+          done();
+        });
+      });
+    });
+
+    test('does not do anything if value does not change', function (done) {
+      var el = entityFactory();
+      el.setAttribute('light', 'type: ambient');
+      el.addEventListener('loaded', function () {
+        el.setComponentAttribute('light', 'type', 'ambient');
+        process.nextTick(function () {
+          assert.equal(el.getComponentData('light').type, 'ambient');
+          done();
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Blocks more granular animatons.
- `getComputedAttribute` was conflating with `getAttribute`. `getComponentData` seems immediately clear what it returns, and is more focused since it will return `null` in case the component does not exist. I'm even thinking we stop overriding HTML's getAttribute and move it to a separate method to make it more predictable.
- Add `setComponentAttribute` to ease programmatic ergonomics.
- Add `getComponentAttribute` to match wtih `setComputedAttribute`
