### PR TITLE
link to `http` (not `https`) for aframe.io

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -13,7 +13,7 @@
   <body>
     <h1>A-Frame Core Examples</h1>
     <p class="note">
-      <a href="https://aframe.io">aframe.io</a>
+      <a href="http://aframe.io">aframe.io</a>
     </p>
     <ul class="links">
       <a-example-link href="animation/">Animation</a-example-link>


### PR DESCRIPTION
see MozVR/aframe-site#12
