### PR TITLE
improve/fix setAttribute (fixes #235)

### DIFF
--- a/tests/core/a-object.test.js
+++ b/tests/core/a-object.test.js
@@ -9,36 +9,28 @@ var mixinFactory = helpers.mixinFactory;
 suite('a-object', function () {
   'use strict';
 
+  setup(function (done) {
+    var el = this.el = entityFactory();
+    el.addEventListener('loaded', function () {
+      done();
+    });
+  });
+
   test('adds itself to parent when attached', function (done) {
     var el = document.createElement('a-object');
-    var parentEl = entityFactory();
+    var parentEl = this.el;
 
     el.object3D = new THREE.Mesh();
-    parentEl.addEventListener('loaded', function () {
-      parentEl.appendChild(el);
-      el.addEventListener('loaded', function () {
-        assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
-        done();
-      });
+    parentEl.appendChild(el);
+    el.addEventListener('loaded', function () {
+      assert.equal(parentEl.object3D.children[0].uuid, el.object3D.uuid);
+      done();
     });
   });
 
   suite('attachedCallback', function () {
-    test('initializes 3D object', function (done) {
-      var el = entityFactory();
-      el.addEventListener('loaded', function () {
-        assert.isDefined(el.object3D);
-        done();
-      });
-    });
-
-    test('calls load method', function (done) {
-      var el = entityFactory();
-      this.sinon.spy(AObject.prototype, 'load');
-      el.addEventListener('loaded', function () {
-        sinon.assert.called(AObject.prototype.load);
-        done();
-      });
+    test('initializes 3D object', function () {
+      assert.isDefined(this.el.object3D);
     });
   });
 
@@ -46,13 +38,6 @@ suite('a-object', function () {
    * Tests full component set + get flow on one of the most basic components.
    */
   suite('attributeChangedCallback', function () {
-    setup(function (done) {
-      var el = this.el = entityFactory();
-      el.addEventListener('loaded', function () {
-        done();
-      });
-    });
-
     test('can remove component', function () {
       var el = this.el;
       el.setAttribute('geometry', 'primitive: box');
@@ -96,27 +81,11 @@ suite('a-object', function () {
 
   suite('detachedCallback', function () {
     test('removes itself from object parent', function (done) {
-      var parentEl = entityFactory();
+      var parentEl = this.el;
       var el = document.createElement('a-object');
 
-      parentEl.addEventListener('loaded', function () {
-        parentEl.appendChild(el);
-
-        el.addEventListener('loaded', function () {
-          parentEl.removeChild(el);
-          process.nextTick(function () {
-            assert.equal(parentEl.object3D.children.length, 0);
-            done();
-          });
-        });
-      });
-    });
-
-    test('removes itself from scene parent', function (done) {
-      var el = entityFactory();
-      var parentEl = el.parentNode;
-
       parentEl.appendChild(el);
+
       el.addEventListener('loaded', function () {
         parentEl.removeChild(el);
         process.nextTick(function () {
@@ -125,44 +94,107 @@ suite('a-object', function () {
         });
       });
     });
+
+    test('removes itself from scene parent', function (done) {
+      var el = this.el;
+      var parentEl = el.parentNode;
+      parentEl.removeChild(el);
+      process.nextTick(function () {
+        assert.equal(parentEl.object3D.children.length, 0);
+        done();
+      });
+    });
   });
 
   suite('getAttribute', function () {
-    test('returns parsed component data', function (done) {
+    test('returns parsed component data', function () {
       var componentData;
-      var el = entityFactory();
-      el.addEventListener('loaded', function () {
-        el.setAttribute('geometry', 'primitive: box; width: 5');
-        process.nextTick(function () {
-          componentData = el.getAttribute('geometry');
-          assert.equal(componentData.width, 5);
-          assert.notOk('height' in componentData);
-          done();
-        });
-      });
+      var el = this.el;
+      el.setAttribute('geometry', 'primitive: box; width: 5');
+      componentData = el.getAttribute('geometry');
+      assert.equal(componentData.width, 5);
+      assert.notOk('height' in componentData);
+    });
+
+    test('returns empty object if component is at defaults', function () {
+      var el = this.el;
+      el.setAttribute('material', '');
+      assert.shallowDeepEqual(el.getAttribute('material'), {});
+    });
+
+    test('returns parsed component data', function () {
+      var componentData;
+      var el = this.el;
+      el.setAttribute('geometry', 'primitive: box; width: 5');
+      componentData = el.getAttribute('geometry');
+      assert.equal(componentData.width, 5);
+      assert.notOk('height' in componentData);
     });
   });
 
   suite('getComputedAttribute', function () {
-    test('returns fully parsed component data', function (done) {
+    test('returns fully parsed component data', function () {
       var componentData;
-      var el = entityFactory();
-      el.addEventListener('loaded', function () {
-        el.setAttribute('geometry', 'primitive: box; width: 5');
-        process.nextTick(function () {
-          componentData = el.getComputedAttribute('geometry');
-          assert.equal(componentData.primitive, 'box');
-          assert.equal(componentData.width, 5);
-          assert.ok('height' in componentData);
-          done();
-        });
-      });
+      var el = this.el;
+      el.setAttribute('geometry', 'primitive: box; width: 5');
+      componentData = el.getComputedAttribute('geometry');
+      assert.equal(componentData.primitive, 'box');
+      assert.equal(componentData.width, 5);
+      assert.ok('height' in componentData);
     });
   });
 
   suite('setAttribute', function () {
+    test('can set a component with a string', function () {
+      var el = this.el;
+      var material;
+      el.setAttribute('material', 'color: #F0F; metalness: 0.75');
+      material = el.getAttribute('material');
+      assert.equal(material.color, '#F0F');
+      assert.equal(material.metalness, 0.75);
+    });
+
+    test('can set a component with an object', function () {
+      var el = this.el;
+      var material;
+      var value = { color: '#F0F', metalness: 0.75 };
+      el.setAttribute('material', value);
+      material = el.getAttribute('material');
+      assert.equal(material.color, '#F0F');
+      assert.equal(material.metalness, 0.75);
+    });
+
+    test('can update a component with an object', function () {
+      var el = this.el;
+      var material;
+      var value = { color: '#000', metalness: 0.75 };
+      el.setAttribute('material', 'color: #F0F; roughness: 0.25');
+      el.setAttribute('material', value);
+      material = el.getAttribute('material');
+      assert.equal(material.color, '#000');
+      assert.equal(material.roughness, 0.25);
+      assert.equal(material.metalness, 0.75);
+    });
+
+    test('can set a single component via a single attribute', function () {
+      var el = this.el;
+      el.setAttribute('material', 'color', '#F0F');
+      assert.equal(el.getAttribute('material').color, '#F0F');
+    });
+
+    test('can update a single component attribute', function () {
+      var el = this.el;
+      var material;
+      el.setAttribute('material', 'color: #F0F; roughness: 0.25');
+      assert.equal(el.getAttribute('material').roughness, 0.25);
+      el.setAttribute('material', 'roughness', 0.75);
+      material = el.getAttribute('material');
+      assert.equal(material.color, '#F0F');
+      assert.equal(material.roughness, 0.75);
+    });
+
     test('transforms object to string before setting on DOM', function () {
-      var el = entityFactory();
+      var el = this.el;
       var positionObj = { x: 10, y: 20, z: 30 };
       el.setAttribute('position', positionObj);
       assert.ok(el.outerHTML.indexOf('position="10 20 30"') !== -1);


### PR DESCRIPTION
This was initially done in https://github.com/MozVR/aframe-core/pull/463/files

And then it was folded into the synchronous setAttribute work. The new component setAttribute logic was not ported all the way and got bloated along the way. 

Using the tests from the previous PR, I improved the setAttribute code to work as desired (to be able to update component attributes with objects in setAttribute). I was able to simplify it and make it take way less code as well.
