### PR TITLE
Animation Fix

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -3,7 +3,6 @@ var debug = require('../utils/debug');
 var registerComponent = require('../core/register-component').registerComponent;
 var srcLoader = require('../utils/src-loader');
 var THREE = require('../../lib/three');
-var utils = require('../utils/');
 
 var CubeLoader = new THREE.CubeTextureLoader();
 var error = debug('components:material:error');

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -91,7 +91,6 @@ module.exports = registerElement('a-animation', {
         if (el.isNode) {
           init();
         } else {
-          el.addEventListener('nodeready', this.init.bind(this));
           // To handle elements that are not yet `<a-object>`s (e.g., templates).
           el.addEventListener('nodeready', init.bind(self));
         }
@@ -99,6 +98,7 @@ module.exports = registerElement('a-animation', {
         function init () {
           self.bindMethods();
           self.applyMixin();
+          self.update();
           self.load();
         }
       }
@@ -194,7 +194,8 @@ module.exports = registerElement('a-animation', {
           this.stop();
           this.start();
         }
-      }
+      },
+      writable: window.debug
     },
 
     /**
@@ -285,7 +286,7 @@ module.exports = registerElement('a-animation', {
     addEventListeners: {
       value: function (evts) {
         var el = this.el;
-        var start = this.start;
+        var start = this.start.bind(this);
         utils.splitString(evts).forEach(function (evt) {
           el.addEventListener(evt, start);
         });

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -1,5 +1,6 @@
-/* global assert, setup, suite, test */
+/* global assert, setup, suite, sinon, test */
 var helpers = require('../helpers.js');
+var AAnimation = require('core/a-animation');
 
 /**
  * Helpers to start initialize an animation.
@@ -50,6 +51,16 @@ suite('a-animation', function () {
         mixin: 'walt'
       }, function (el, animationEl) {
         assert.equal(animationEl.data.repeat, 'indefinite');
+        done();
+      });
+    });
+  });
+
+  suite('update', function () {
+    test('it is called on initialization', function (done) {
+      this.sinon.stub(AAnimation.prototype, 'update');
+      setupAnimation({}, function (el, animationEl) {
+        sinon.assert.called(AAnimation.prototype.update);
         done();
       });
     });
@@ -196,6 +207,19 @@ suite('a-animation', function () {
 
     test('sets isRunning', function (done) {
       setupAnimation({}, function (el, animationEl) {
+        assert.ok(animationEl.isRunning);
+        done();
+      });
+    });
+
+    test('sets isRunning when begin event is triggered', function (done) {
+      var animationEl = document.createElement('a-animation');
+      animationEl.setAttribute('begin', 'click');
+      var el = helpers.entityFactory();
+      el.setAttribute('material', {color: 'red'});
+      el.appendChild(animationEl);
+      animationEl.addEventListener('loaded', function () {
+        el.emit('click');
         assert.ok(animationEl.isRunning);
         done();
       });


### PR DESCRIPTION
Fix animations:
1. this.start was not bound to the animation object when attached to the eventListeners
2. update was not called on initalization
3. There was two evenlisteners on `nodeready` event. One of them to a method that doesn't exist. Possibly a left over from a rebase or merge conflict
4. It adds unit tests covering the bug.
