### PR TITLE
fix animation not starting at entity default value (fixes #494)

### DIFF
--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -36,7 +36,7 @@ var DEFAULTS = {
   easing: 'ease',
   direction: DIRECTIONS.normal,
   fill: FILLS.forwards,
-  from: { x: 0, y: 0, z: 0 },
+  from: undefined,
   repeat: 0,
   to: undefined
 };

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -138,6 +138,18 @@ suite('a-animation', function () {
     });
   });
 
+  test('fill mode: backwards when `from` is not defined', function (done) {
+    setupAnimation({
+      attribute: 'scale',
+      dur: 100,
+      fill: 'backwards',
+      to: '10 10 10'
+    }, function (el, animationEl) {
+      assert.shallowDeepEqual(el.getAttribute('scale'), { x: 1, y: 1, z: 1 });
+      done();
+    });
+  });
+
   suite('fill mode: both', function () {
     setup(function (done) {
       var self = this;


### PR DESCRIPTION
the defaults object had an incorrectly truthy value from `from` causing the animation to never read the current value of the entity. i added a test which fails before the fix, and passes after the fix:

![scale](https://cloud.githubusercontent.com/assets/674727/11378512/6c300b0c-92a0-11e5-923a-2a5e31cf6ae3.gif)
