### PR TITLE
Updated defaults for cameras and objects, and examples to match. Fixes #469

### DIFF
--- a/examples/animation/index.html
+++ b/examples/animation/index.html
@@ -19,8 +19,8 @@
     </a-assets>
 
     <a-scene stats="true">
-      <a-entity position="0 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity position="0 0 6">
+        <a-entity camera look-controls wasd-controls></a-entity>
       </a-entity>
       <a-entity rotation="0 0 0" position="0 0 -5">
         <!-- Lights. -->

--- a/examples/controls/index.html
+++ b/examples/controls/index.html
@@ -12,12 +12,12 @@
   <body>
     <a-scene stats="true">
       <!-- We wrap the camera in an <a-entity> so we can position it without colliding with the HMD updates -->
-      <a-entity position="0 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity>
+        <a-entity position="0 1.8 4" camera look-controls wasd-controls></a-entity>
       </a-entity>
-      <a-entity position="-10 0 0" rotation="0 45 0" geometry="primitive: box" material="color: red"></a-entity>
-      <a-entity position="0 0 0" rotation="0 45 0" geometry="primitive: box" material="color: green"></a-entity>
-      <a-entity class="cube" position="10 0 0" rotation="0 45 0" geometry="primitive: box" material="color: blue"></a-entity>
+      <a-entity position="-3.5 1 0" rotation="0 45 0" geometry="primitive: box" material="color: red"></a-entity>
+      <a-entity position="0 1 0" rotation="0 45 0" geometry="primitive: box" material="color: green"></a-entity>
+      <a-entity position="3.5 1 0" rotation="0 45 0" geometry="primitive: box" material="color: blue"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/cube/index.html
+++ b/examples/cube/index.html
@@ -14,8 +14,8 @@
   <body>
     <a-scene stats="true">
       <!-- Cube -->
-      <a-entity position="0 0 -20" rotation="45 30 0"
-                geometry="primitive: box; height: 10; width: 10; depth: 10;"
+      <a-entity position="0 0 -10" rotation="45 30 0"
+                geometry="primitive: box; height: 8; width: 8; depth: 8;"
                 material="color: #167341; roughness: 1.0; metalness: 0.2;"></a-entity>
     </a-scene>
   </body>

--- a/examples/cursor/index.html
+++ b/examples/cursor/index.html
@@ -21,8 +21,8 @@
     </a-assets>
 
     <a-scene stats="true">
-      <a-entity position="-3 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls>
+      <a-entity position="0 2.2 4">
+        <a-entity camera look-controls wasd-controls>
           <a-entity position="0 0 -5"
                     geometry="primitive: ring; outerRadius: 0.30;
                               innerRadius: 0.20;"
@@ -31,21 +31,21 @@
         </a-entity>
       </a-entity>
 
-      <a-entity position="-10 0 0">
+      <a-entity position="-3.5 1 0">
         <a-entity mixin="cube red">
           <a-animation begin="click" attribute="position" from="0 0 0"
                        to="0 0 -10" dur="2000" fill="both"></a-animation>
         </a-entity>
       </a-entity>
 
-      <a-entity>
+      <a-entity position="0 1 0">
         <a-entity mixin="cube green">
           <a-animation begin="click" attribute="rotation" to="0 360 0"
                        easing="linear" dur="2000" fill="backwards"></a-animation>
         </a-entity>
       </a-entity>
 
-      <a-entity position="10 0 0" rotation="0 45 0">
+      <a-entity position="3.5 1 0" rotation="0 45 0">
         <a-entity mixin="cube blue">
           <a-animation begin="click" fill="forwards" repeat="1"
                        direction="alternate" attribute="position" from="0 0 0"
@@ -53,7 +53,7 @@
         </a-entity>
       </a-entity>
 
-      <a-entity class="clickable" mixin="cube yellow" position="0 -5 0"
+      <a-entity position="0 3 0" class="clickable" mixin="cube yellow"
                 rotation="0 45 0" scale=".5 .5 .5"></a-entity>
     </a-scene>
 

--- a/examples/cylinders/index.html
+++ b/examples/cylinders/index.html
@@ -15,8 +15,8 @@
                                 material="side: double"></a-mixin>
     </a-assets>
     <a-scene stats="true">
-      <a-entity position="0 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity position="0 0 8">
+        <a-entity camera look-controls wasd-controls></a-entity>
       </a-entity>
 
       <a-entity mixin="cylinder" position="-10 0 0" rotation="45 0 -45"
@@ -32,7 +32,7 @@
                 geometry="radius: 4; height: 2; thetaLength: 3; thetaStart: 3"
                 material="color: orchid"></a-entity>
 
-      <a-entity mixin="cylinder" position="4 -5 0" rotation="0 0 0"
+      <a-entity mixin="cylinder" position="5 -5 0" rotation="-45 0 0"
                 geometry="radiusTop: 3; radiusBottom: 0.1; height: 2"
                 material="color: green"></a-entity>
     </a-scene>

--- a/examples/fog/index.html
+++ b/examples/fog/index.html
@@ -11,45 +11,49 @@
 
   <body>
     <a-assets>
-      <a-mixin id="move" attribute="position" direction="alternate" dur="8192"
+      <a-mixin id="move" attribute="position" direction="alternate" dur="4096"
                          fill="forwards" easing="linear" repeat="indefinite">
       </a-mixin>
-      <a-mixin id="box" geometry="primitive: torusKnot; p: 3; q: 11; tube: .5"
+      <a-mixin id="box" geometry="primitive: torusKnot; p: 3; q: 11; tube: .5; radius: 10"
                         material="color: #2F3C4F"></a-mixin>
       <a-mixin id="spin" attribute="rotation" dur="4096" to="-360 0 0"
                          easing="linear" repeat="indefinite"></a-mixin>
     </a-assets>
-    <a-scene fog="type: linear; color: #AAB; far: 120; near: 5"
+    <a-scene fog="type: linear; color: #AAB; far: 120; near: 0"
              stats="true">
       <!-- Camera. -->
       <a-entity position="0 1.8 0">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+        <a-entity camera look-controls wasd-controls></a-entity>
       </a-entity>
 
       <!-- Skysphere. -->
-      <a-entity geometry="primitive: sphere; radius: 80"
+      <a-entity geometry="primitive: sphere; radius: 120"
                 material="shader: flat;
                           src: url(../_images/pano/louvre.jpg)"
-                position="0 1.8 0" scale="1 1 -1"></a-entity>
+                position="0 1.8 0" scale="1 1 -1" rotation="0 90 0"></a-entity>
 
-      <a-entity mixin="box" position="-40 0 0">
-        <a-animation mixin="move" from="-40 0 0 " to="-80 0 0">
+      <a-entity mixin="box" position="-30 0 0">
+        <a-animation mixin="move" to="-100 0 0">
         </a-animation>
         <a-animation mixin="spin"></a-animation>
       </a-entity>
-      <a-entity mixin="box" position="40 0 0">
-        <a-animation mixin="move" from="40 0 0" to="80 0 0"></a-animation>
+
+      <a-entity mixin="box" position="30 0 0">
+        <a-animation mixin="move" to="100 0 0"></a-animation>
         <a-animation mixin="spin"></a-animation>
       </a-entity>
-      <a-entity mixin="box" position="0 0 -40">
-        <a-animation mixin="move" from="0 0 -40" to="0 0 -80">
+
+      <a-entity mixin="box" position="0 0 -30">
+        <a-animation mixin="move" to="0 0 -100">
         </a-animation>
         <a-animation mixin="spin"></a-animation>
       </a-entity>
-      <a-entity mixin="box" position="0 0 40">
-        <a-animation mixin="move" from="0 0 40" to="0 0 80"></a-animation>
+
+      <a-entity mixin="box" position="0 0 30">
+        <a-animation mixin="move" to="0 0 100"></a-animation>
         <a-animation mixin="spin"></a-animation>
       </a-entity>
+
     </a-scene>
   </body>
 </html>

--- a/examples/geometries/index-gallery.html
+++ b/examples/geometries/index-gallery.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Geometries</title>
+    <meta name="description" content="Geometries — A-Frame Core">
+    <link rel="stylesheet" type="text/css" href="../../style/aframe-core.css">
+    <link rel="stylesheet" type="text/css" href="../_style/main.css">
+    <script src="../../build/aframe-core.js"></script>
+  </head>
+  <body>
+    <a-assets>
+      <!-- Geometry mixins. -->
+      <a-mixin id="box"
+               geometry="primitive: box; depth: .125; height: .125;
+                         width: .125"></a-mixin>
+      <a-mixin id="circle"
+               geometry="primitive: circle; openEnded: true; radius: .2;
+                         segments: 100; thetaStart: 0; thetaEnd: 3">
+      </a-mixin>
+      <a-mixin id="cylinder"
+               geometry="primitive: cylinder; radius: 0.2; height: .5;
+                         segmentsRadius: 50; segmentsHeight: 50:
+                         openEnded: true; thetaStart: 0; thetaEnd: 3">
+      </a-mixin>
+      <a-mixin id="ring"
+                geometry="primitive: ring; innerRadius: .3;
+                          openEnded: true; outerRadius: .5;
+                          segments: 50"></a-mixin>
+      <a-mixin id="sphere"
+                geometry="primitive: sphere; radius: .1"></a-mixin>
+      <a-mixin id="torus"
+                geometry="primitive: torus; arc: 6; radius: .3; tube: .05;
+                          segments: 32; tubularSegments: 10;"></a-mixin>
+      <a-mixin id="torus-knot"
+                geometry="primitive: torusKnot; p: 3; q: 7; radius: .25;
+                          segments: 32; tube: .07; tubularSegments: 10">
+      </a-mixin>
+
+      <!-- Layout mixins. -->
+      <a-mixin id="column"
+                geometry="primitive: box; depth: .75; height: 1.2; width: .75"
+                material="color: #FFF" position="0 .6 0"></a-mixin>
+      <a-mixin id="column-bottom" geometry="primitive: box; depth: 1;
+                                            height: .1; width: 1;"
+               material="color: #FFF" position="0 .1 0">
+      </a-mixin>
+      <a-mixin id="column-light" light="type: point; intensity: 0.5;
+                                        distance: 5;"
+                position="0 1.5 0">
+      </a-mixin>
+      <a-mixin id="object-on-column" position="0 1.2 0"></a-mixin>
+
+      <!-- Animation mixins. -->
+      <a-mixin id="yoyo" direction="alternate" fill="forwards"
+                         repeat="indefinite"></a-mixin>
+      <a-mixin id="spin" attribute="rotation" to="0 360 0"
+               repeat="indefinite" easing="linear" dur="10000"></a-mixin>
+      <a-mixin id="spin-x" mixin="spin" attribute="rotation" to="360 0 0"
+               repeat="indefinite" easing="linear" dur="10000"></a-mixin>
+
+      <a-mixin id="color" material="color: #FFFFC3"></a-mixin>
+      <a-mixin id="doubleside" material="side: double"></a-mixin>
+
+      <img id="carpet" src="../_images/textures/carpet.jpg">
+      <img id="floor" src="../_images/textures/marble.jpg">
+    </a-assets>
+
+    <a-scene stats="true">
+      <!-- Camera. -->
+      <a-entity position="0 1.8 0">
+        <a-entity camera look-controls wasd-controls>
+        </a-entity>
+      </a-entity>
+
+      <!-- Lights. -->
+      <a-entity light="type: ambient; color: #444"></a-entity>
+      <a-entity light="type: directional; color: #EEE"
+                position="0 1 1">
+      </a-entity>
+
+      <!-- Skysphere. -->
+      <a-entity geometry="primitive: sphere; radius: 80"
+                material="color: #112; shader: flat" scale="1 1 -1">
+      </a-entity>
+
+      <!-- Floor. -->
+      <a-entity geometry="primitive: cylinder; height: .2; radius: 12;"
+                material="color: #BABABA; src: #floor;
+                          metallic: .2; repeat: 50 20; roughness: .1"
+                position="0 0 0"></a-entity>
+
+      <!-- Carpet. -->
+      <a-entity geometry="primitive: box; depth: 20; height: 0.025; width: 2"
+                material="color: #440000; metallic: 0; src: #carpet;
+                          repeat: 3 40; roughness: 1"
+                position="0 .2 0">
+      </a-entity>
+
+      <!-- Boxes. -->
+      <a-entity position="-2.5 0 1">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color box">
+            <a-animation mixin="spin" to="360 360 0"></a-animation>
+          </a-entity>
+          <a-entity mixin="object-on-column color box" position=".18 1.2 .1">
+            <a-animation mixin="spin" to="360 360 0"></a-animation>
+          </a-entity>
+          <a-entity mixin="object-on-column color box"
+                    position="-.18 1.2 -.2">
+            <a-animation mixin="spin" to="360 360 0"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+
+      <!-- Circles. -->
+      <a-entity position="-2.5 0 -2">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color doubleside circle">
+            <a-animation mixin="spin"></a-animation>
+          </a-entity>
+          <a-entity mixin="object-on-column color doubleside circle">
+            <a-animation mixin="spin-x"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+
+      <!-- Cylinders. -->
+      <a-entity position="-2.5 0 -5">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color cylinder">
+            <a-animation mixin="spin-x"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+
+      <!-- Rings. -->
+      <a-entity position="2.5 0 1">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color doubleside ring">
+            <a-animation mixin="spin" dur="6000"></a-animation>
+          </a-entity>
+          <a-entity mixin="object-on-column color doubleside ring">
+            <a-animation mixin="spin" to="360 0 0" dur="6000"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+
+      <!-- Spheres. -->
+      <a-entity position="2.5 0 -2">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color sphere"
+                    position="-.2 1.2 0">
+            <a-animation mixin="yoyo" attribute="position" from="-.2 1 0"
+                         to="-.2 1.8 0"></a-animation>
+          </a-entity>
+          <a-entity mixin="object-on-column color sphere">
+            <a-animation mixin="yoyo" attribute="position" from="0 1.8 0"
+                         to="0 1 0" ></a-animation>
+          </a-entity>
+          <a-entity mixin="object-on-column color sphere" position=".2 1 0">
+            <a-animation mixin="yoyo" attribute="position" from=".2 1 0"
+                         to=".2 1.8 0"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+
+      <!-- Torus. -->
+      <a-entity position="2.5 0 -5">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color torus">
+            <a-animation mixin="spin"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+
+      <!-- Torus Knot. -->
+      <a-entity position="2.5 0 -8">
+        <a-entity mixin="column">
+          <a-entity mixin="column-light"></a-entity>
+          <a-entity mixin="object-on-column color torus-knot">
+            <a-animation mixin="spin"></a-animation>
+          </a-entity>
+        </a-entity>
+        <a-entity mixin="column-bottom"></a-entity>
+      </a-entity>
+    </a-scene>
+  </body>
+</html>

--- a/examples/geometries/index.html
+++ b/examples/geometries/index.html
@@ -9,193 +9,21 @@
     <script src="../../build/aframe-core.js"></script>
   </head>
   <body>
-    <a-assets>
-      <!-- Geometry mixins. -->
-      <a-mixin id="box"
-               geometry="primitive: box; depth: .125; height: .125;
-                         width: .125"></a-mixin>
-      <a-mixin id="circle"
-               geometry="primitive: circle; openEnded: true; radius: .2;
-                         segments: 100; thetaStart: 0; thetaEnd: 3">
-      </a-mixin>
-      <a-mixin id="cylinder"
-               geometry="primitive: cylinder; radius: 0.2; height: .5;
-                         segmentsRadius: 50; segmentsHeight: 50:
-                         openEnded: true; thetaStart: 0; thetaEnd: 3">
-      </a-mixin>
-      <a-mixin id="ring"
-                geometry="primitive: ring; innerRadius: .3;
-                          openEnded: true; outerRadius: .5;
-                          segments: 50"></a-mixin>
-      <a-mixin id="sphere"
-                geometry="primitive: sphere; radius: .1"></a-mixin>
-      <a-mixin id="torus"
-                geometry="primitive: torus; arc: 6; radius: .3; tube: .05;
-                          segments: 32; tubularSegments: 10"></a-mixin>
-      <a-mixin id="torus-knot"
-                geometry="primitive: torusKnot; p: 3; q: 7; radius: .35;
-                          segments: 32; tube: .1; tubularSegments: 10">
-      </a-mixin>
-
-      <!-- Layout mixins. -->
-      <a-mixin id="column"
-                geometry="primitive: box; depth: .75; height: 1.5; width: .75"
-                material="color: #FFF" position="0 .75 0"></a-mixin>
-      <a-mixin id="column-bottom" geometry="primitive: box; depth: 1;
-                                            height: .1; width: 1;"
-               material="color: #FFF" position="0 .1 0">
-      </a-mixin>
-      <a-mixin id="column-light" light="type: point; intensity: 1;
-                                        distance: 5;"
-                position="0 1.5 0">
-      </a-mixin>
-      <a-mixin id="object-on-column" position="0 1.4 0"></a-mixin>
-
-      <!-- Animation mixins. -->
-      <a-mixin id="yoyo" direction="alternate" fill="forwards"
-                         repeat="indefinite"></a-mixin>
-      <a-mixin id="spin" attribute="rotation" to="0 360 0"
-               repeat="indefinite" easing="linear" dur="10000"></a-mixin>
-      <a-mixin id="spin-x" mixin="spin" attribute="rotation" to="360 0 0"
-               repeat="indefinite" easing="linear" dur="10000"></a-mixin>
-
-      <a-mixin id="color" material="color: #FFFFC3"></a-mixin>
-      <a-mixin id="doubleside" material="side: double"></a-mixin>
-
-      <img id="carpet" src="../_images/textures/carpet.jpg">
-      <img id="floor" src="../_images/textures/marble.jpg">
-    </a-assets>
-
+    
     <a-scene stats="true">
-      <!-- Camera. -->
-      <a-entity position="0 1.8 0">
-        <a-entity camera="fov: 45" look-controls wasd-controls>
-        </a-entity>
-      </a-entity>
-
-      <!-- Lights. -->
-      <a-entity light="type: ambient; color: #444"></a-entity>
-      <a-entity light="type: directional; color: #EEE"
-                position="0 1 1">
-      </a-entity>
-
-      <!-- Skysphere. -->
-      <a-entity geometry="primitive: sphere; radius: 80"
-                material="color: #112; shader: flat" scale="1 1 -1">
-      </a-entity>
-
-      <!-- Floor. -->
-      <a-entity geometry="primitive: cylinder; height: .2; radius: 25;"
-                material="color: #BABABA; src: #floor;
-                          metallic: .2; repeat: 50 20; roughness: .1"
-                position="0 0 -25"></a-entity>
-
-      <!-- Carpet. -->
-      <a-entity geometry="primitive: box; depth: 50; height: 0.025; width: 2"
-                material="color: #440000; metallic: 0; src: #carpet;
-                          repeat: 3 40; roughness: 1"
-                position="0 .2 -25">
-      </a-entity>
-
+      
       <!-- Boxes. -->
-      <a-entity position="-2.5 0 -5">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color box">
-            <a-animation mixin="spin" to="360 360 0"></a-animation>
-          </a-entity>
-          <a-entity mixin="object-on-column color box" position=".18 1.2 .1">
-            <a-animation mixin="spin" to="360 360 0"></a-animation>
-          </a-entity>
-          <a-entity mixin="object-on-column color box"
-                    position="-.18 1.2 -.2">
-            <a-animation mixin="spin" to="360 360 0"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
+      <a-entity geometry="primitive: box" position="-4.5 0 0"></a-entity>
+      <a-entity geometry="primitive: circle" position="-1.5 0 0"></a-entity>
+      <a-entity geometry="primitive: cylinder" position="1.5 0 0"></a-entity>
+      <a-entity geometry="primitive: plane" position="4.5 0 0"></a-entity>
 
-      <!-- Circles. -->
-      <a-entity position="-2.5 0 -15">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color doubleside circle">
-            <a-animation mixin="spin"></a-animation>
-          </a-entity>
-          <a-entity mixin="object-on-column color doubleside circle">
-            <a-animation mixin="spin-x"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
+      <a-entity geometry="primitive: ring" position="-4.5 3 0"></a-entity>
+      <a-entity geometry="primitive: sphere" position="-1.5 3 0"></a-entity>
+      <a-entity geometry="primitive: torus" position="1.5 3 0"></a-entity>
+      <a-entity geometry="primitive: torusKnot" position="4.5 3 0"></a-entity>
 
-      <!-- Cylinders. -->
-      <a-entity position="-2.5 0 -25">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color cylinder">
-            <a-animation mixin="spin-x"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
 
-      <!-- Rings. -->
-      <a-entity position="2.5 0 -5">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color doubleside ring">
-            <a-animation mixin="spin" dur="6000"></a-animation>
-          </a-entity>
-          <a-entity mixin="object-on-column color doubleside ring">
-            <a-animation mixin="spin" to="360 0 0" dur="6000"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
-
-      <!-- Spheres. -->
-      <a-entity position="2.5 0 -15">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color sphere"
-                    position="-.2 1.2 0">
-            <a-animation mixin="yoyo" attribute="position" from="-.2 1 0"
-                         to="-.2 1.8 0"></a-animation>
-          </a-entity>
-          <a-entity mixin="object-on-column color sphere">
-            <a-animation mixin="yoyo" attribute="position" from="0 1.8 0"
-                         to="0 1 0" ></a-animation>
-          </a-entity>
-          <a-entity mixin="object-on-column color sphere" position=".2 1 0">
-            <a-animation mixin="yoyo" attribute="position" from=".2 1 0"
-                         to=".2 1.8 0"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
-
-      <!-- Torus. -->
-      <a-entity position="2.5 0 -25">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color torus">
-            <a-animation mixin="spin"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
-
-      <!-- Torus Knot. -->
-      <a-entity position="2.5 0 -35">
-        <a-entity mixin="column">
-          <a-entity mixin="column-light"></a-entity>
-          <a-entity mixin="object-on-column color torus-knot">
-            <a-animation mixin="spin"></a-animation>
-          </a-entity>
-        </a-entity>
-        <a-entity mixin="column-bottom"></a-entity>
-      </a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -23,13 +23,14 @@
       <a-example-link href="cylinders/">Cylinders</a-example-link>
       <a-example-link href="fog/">Fog</a-example-link>
       <a-example-link href="geometries/">Geometries</a-example-link>
+      <a-example-link href="geometries/index-gallery.html">Geometries Gallery</a-example-link>
       <a-example-link href="lights/">Lights</a-example-link>
       <a-example-link href="look-at/">Look-At</a-example-link>
       <a-example-link href="mixin/">Mixin</a-example-link>
       <a-example-link href="model/">Model</a-example-link>
       <a-example-link href="opacity/">Opacity</a-example-link>
-      <a-example-link href="physical/">Physically-Based Materials</a-example-link>
       <a-example-link href="panoexplorer/">Pano Explorer</a-example-link>
+      <a-example-link href="physical/">Physically-Based Materials</a-example-link>
       <a-example-link href="texture/">Texture</a-example-link>
       <a-example-link href="towers/">Towers</a-example-link>
       <a-example-link href="video/">Video</a-example-link>

--- a/examples/lights/index.html
+++ b/examples/lights/index.html
@@ -20,8 +20,8 @@
   </a-assets>
   <a-scene stats="true">
     <!-- Camera. -->
-    <a-entity position="0 0 150">
-      <a-entity camera="fov: 60" look-controls wasd-controls></a-entity>
+    <a-entity position="0 0 120">
+      <a-entity camera look-controls wasd-controls></a-entity>
     <a-entity>
 
     <!-- Skysphere. -->
@@ -66,6 +66,7 @@
       obj.setAttribute('geometry', {
         primitive: 'torusKnot',
         radius: Math.random() * 10,
+        tube: 2,
         p: Math.round(Math.random() * 10),
         q: Math.round(Math.random() * 10)
       });

--- a/examples/look-at/index.html
+++ b/examples/look-at/index.html
@@ -12,15 +12,15 @@
     <a-assets>
       <img id="floor" src="../_images/textures/marble.jpg">
       <img id="follower-img" src="../_images/pano/tintamarre.jpg">
-      <a-mixin id="follower" geometry="primitive: box; depth: .1;"
+      <a-mixin id="follower" geometry="primitive: box; width: 3; height: 3; depth: .1;"
                material="src: #follower-img">
       </a-mixin>
     </a-assets>
 
     <a-scene stats="true">
       <!-- Camera. -->
-      <a-entity position="0 1.8 15">
-        <a-entity id="camera" camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity position="0 1.8 4">
+        <a-entity id="camera" camera look-controls wasd-controls></a-entity>
       </a-entity>
 
       <!-- Light. -->
@@ -48,8 +48,8 @@
                      to="0 360 180"></a-animation>
       </a-entity>
 
-      <a-entity mixin="follower" look-at="#squirrel" position="0 3 0"></a-entity>
-      <a-entity mixin="follower" look-at="#camera" position="0 10 0"></a-entity>
+      <a-entity mixin="follower" look-at="#squirrel" position="0 2 0"></a-entity>
+      <a-entity mixin="follower" look-at="#camera" position="0 5 0"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/mixin/index.html
+++ b/examples/mixin/index.html
@@ -14,13 +14,10 @@
       <a-mixin id="sphere" geometry="primitive: sphere" material="color: blue"></a-mixin>
     </a-assets>
     <a-scene stats="true">
-      <a-entity position="0 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
-      </a-entity>
       <!-- specialization of a particular component with an applied mixin -->
-      <a-entity mixin="cube" position="-10 0 0" material="color: yellow"></a-entity>
-      <a-entity mixin="cube"></a-entity>
-      <a-entity mixin="cube" position="10 0 0"></a-entity>
+      <a-entity mixin="cube" position="-3.5 1 0" material="color: yellow"></a-entity>
+      <a-entity mixin="cube" position="0 1 0"></a-entity>
+      <a-entity mixin="cube" position="3.5 1 0"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/model/index.html
+++ b/examples/model/index.html
@@ -10,12 +10,12 @@
   </head>
   <body>
     <a-scene stats="true">
-      <a-entity mouse-controls position="0 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity mouse-controls position="0 0 10">
+        <a-entity camera look-controls wasd-controls></a-entity>
       </a-entity>
       <a-entity loader="src: url(models/monster.dae); format: collada"
                 material="color: green" scale="0.25 0.25 0.25"
-                position="-5 -3 0"></a-entity>
+                position="-8 -3 1"></a-entity>
     </a-scene>
   </body>
 </html>

--- a/examples/opacity/index.html
+++ b/examples/opacity/index.html
@@ -10,14 +10,14 @@
   </head>
   <body>
     <a-scene stats="true">
-      <a-entity position="0 0 20">
-          <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity position="0 1.8 4">
+          <a-entity camera look-controls wasd-controls></a-entity>
       </a-entity>
-      <a-entity position="-10 0 0" rotation="0 45 0" geometry="primitive: box" material="color: red; opacity: 0.25">
+      <a-entity position="-3.5 1 0" rotation="0 45 0" geometry="primitive: box" material="color: red; opacity: 0.25">
         <a-entity class="cube" position="0 0 0" rotation="0 45 0" scale="0.5 0.5 0.5" geometry="primitive: box" material="color: red"></a-entity>
       </a-entity>
-      <a-entity position="0 0 0" rotation="0 45 0" geometry="primitive: box" material="color: green"></a-entity>
-      <a-entity class="cube" position="10 0 0" rotation="0 45 0" geometry="primitive: box" material="color: blue; src: url(https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Trefoil_knot_left.svg/2000px-Trefoil_knot_left.svg.png); opacity: 0.5">
+      <a-entity position="0 1 0" rotation="0 45 0" geometry="primitive: box" material="color: green"></a-entity>
+      <a-entity class="cube" position="3.5 1 0" rotation="0 45 0" geometry="primitive: box" material="color: blue; src: url(https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Trefoil_knot_left.svg/2000px-Trefoil_knot_left.svg.png); opacity: 0.5">
         <a-entity class="cube" position="0 0 0" rotation="0 45 0" scale="0.5 0.5 0.5" geometry="primitive: box" material="color: blue"></a-entity>
       </a-entity>
     </a-scene>

--- a/examples/panoexplorer/index.html
+++ b/examples/panoexplorer/index.html
@@ -31,7 +31,7 @@
     <a-scene stats="true">
 
       <!-- Controls -->
-      <a-entity camera="fov: 45" look-controls>
+      <a-entity camera look-controls>
         <a-entity mixin="cursor" position="0 0 -3">
           <a-animation mixin="click-animation"></a-animation>
           <a-animation mixin="fuse-animation"></a-animation>
@@ -43,7 +43,7 @@
                 material="shader: flat" scale="1 1 -1"></a-entity>
 
       <!-- Links to panos -->
-      <a-entity id="links" position="-1 -0.3 -4"></a-entity>
+      <a-entity id="links" position="-1.5 -1 -4"></a-entity>
     </a-scene>
 
     <script>

--- a/examples/physical/index.html
+++ b/examples/physical/index.html
@@ -30,8 +30,8 @@
 
     <a-scene stats="true">
       <!-- Camera. -->
-      <a-entity position="0 1.8 0" rotation="-10 0 0">
-        <a-entity camera="fov: 45" look-controls wasd-controls></a-entity>
+      <a-entity position="0 1.8 0" rotation="0 0 0">
+        <a-entity camera look-controls wasd-controls></a-entity>
       </a-entity>
 
       <!-- Skysphere. -->

--- a/examples/texture/index.html
+++ b/examples/texture/index.html
@@ -11,13 +11,13 @@
   <body>
     <a-assets>
       <img class="louvre" src="../_images/pano/louvre.jpg">
-      <a-mixin id="pano" geometry="primitive: sphere"
+      <a-mixin id="pano" geometry="primitive: sphere; radius: 100;"
                material="src: .louvre; shader: flat"
-               scale="1 1 -1"></a-mixin>
+               scale="1 1 -1" rotation="0 90 0"></a-mixin>
     </a-assets>
     <a-scene stats="true">
       <a-entity>
-        <a-entity camera="fov: 45" look-controls></a-entity>
+        <a-entity camera look-controls></a-entity>
       </a-entity>
       <a-entity mixin="pano"></a-entity>
     </a-scene>

--- a/examples/towers/index.html
+++ b/examples/towers/index.html
@@ -43,7 +43,7 @@
     </a-assets>
 
     <a-scene stats="true">
-      <a-entity id="world" rotation="30 0 0" position="0 0 3"></a-entity>
+      <a-entity id="world" rotation="0 0 0" position="0 -3 0"></a-entity>
 
       <a-entity class="light--light" light="type: directional; color: #fff; intensity: 0.2" position="-10 20 10"></a-entity>
       <a-entity class="light--light" light="type: ambient; color: #eee;"></a-entity>
@@ -130,13 +130,13 @@
         function addTower (opts, numCubes) {
           opts = opts || {};
           if (!('width' in opts)) {
-            opts.width = 1;
+            opts.width = 1.5;
           }
           if (!('height' in opts)) {
             opts.height = 0.25;
           }
           if (!('depth' in opts)) {
-            opts.depth = 1;
+            opts.depth = 1.5;
           }
 
           var firstCubeOpts = Object.assign({rotation: {x: 0, y: 45, z: 0}}, opts);

--- a/examples/video/index.html
+++ b/examples/video/index.html
@@ -17,10 +17,10 @@
     </a-assets>
 
     <a-scene stats="true">
-      <a-entity camera="fov: 45" look-controls></a-entity>
+      <a-entity camera look-controls></a-entity>
       <a-entity material="shader: flat;
                           src: url(https://s3-us-west-2.amazonaws.com/s.cdpn.io/t-197/walking_the_dog_360_video_short.webm)"
-                geometry="primitive: sphere; radius: 5" scale="-1 1 1">
+                geometry="primitive: sphere; radius: 100" scale="-1 1 1">
       </a-entity>
     </a-scene>
   </body>

--- a/examples/visibility/index.html
+++ b/examples/visibility/index.html
@@ -21,39 +21,39 @@
     </a-assets>
 
     <a-scene stats="true">
-      <a-entity position="0 0 20">
-        <a-entity camera="fov: 45" look-controls wasd-controls>
-          <a-entity position="0 0 -5"
-                     geometry="primitive: ring; outerRadius: 0.30;
-                               innerRadius: 0.20"
+      <a-entity position="0 1.8 4">
+        <a-entity camera look-controls wasd-controls>
+          <a-entity position="0 0 -1"
+                     geometry="primitive: ring; outerRadius: 0.05;
+                               innerRadius: 0.03"
                      material="color: red; shader: flat"
-                     cursor="maxDistance: 30"></a-entity>
+                     cursor="maxDistance: 100"></a-entity>
         </a-entity>
       </a-entity>
 
       <a-entity id="blueCube"
-        position="5 0 0"
+        position="0 0 0"
         material="color: blue"
         geometry="primitive: box"
         rotation="25 25 0"></a-entity>
 
       <a-entity id="redSphere"
-        position="5 0 0"
+        position="0 0 0"
         material="color: red"
-        geometry="primitive: sphere; radius: 5"
+        geometry="primitive: sphere;"
         visible="false"></a-entity>
 
       <a-entity id="greenCylinder"
-        position="-7 0 0"
+        position="-3.5 0 0"
         rotation="25 25 0"
         material="color: green"
-        geometry="primitive: cylinder; radius: 5"></a-entity>
+        geometry="primitive: cylinder;"></a-entity>
 
       <a-entity id="pinkTorus"
-        position="16 0 2"
+        position="3.5 0 0"
         rotation="25 -25 0"
         material="color: hotpink"
-        geometry="primitive: torus; radius: 2.5"></a-entity>
+        geometry="primitive: torus;"></a-entity>
     </a-scene>
     <script>
       (function () {

--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -5,8 +5,8 @@ module.exports.Component = registerComponent('camera', {
   defaults: {
     value: {
       far: 10000,
-      fov: 45,
-      near: 1
+      fov: 80,
+      near: 0.5
     }
   },
 

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -4,7 +4,7 @@ var THREE = require('../../lib/three');
 
 var warn = debug('components:geometry:warn');
 
-var DEFAULT_RADIUS = 5;
+var DEFAULT_RADIUS = 1;
 
 /**
  * Geometry component. Combined with material component to make a mesh in
@@ -37,11 +37,11 @@ module.exports.Component = registerComponent('geometry', {
   defaults: {
     value: {
       arc: 2 * Math.PI,
-      depth: 5,
-      height: 5,
-      innerRadius: 5,
+      depth: 2,
+      height: 2,
+      innerRadius: 0.8,
       openEnded: false,
-      outerRadius: 7,
+      outerRadius: 1.2,
       p: 2,
       primitive: '',
       q: 3,
@@ -54,9 +54,9 @@ module.exports.Component = registerComponent('geometry', {
       segmentsWidth: 36,
       thetaLength: 6.3,
       thetaStart: 0,
-      tube: 2,
+      tube: 0.2,
       tubularSegments: 8,
-      width: 5
+      width: 2
     }
   },
 

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -400,9 +400,9 @@ var AScene = module.exports = registerElement('a-scene', {
 
         // DOM calls to create camera.
         cameraWrapperEl = document.createElement('a-entity');
-        cameraWrapperEl.setAttribute('position', {x: 0, y: 1.8, z: 10});
+        cameraWrapperEl.setAttribute('position', {x: 0, y: 1.8, z: 4});
         defaultCamera = document.createElement('a-entity');
-        defaultCamera.setAttribute('camera', {fov: 45});
+        defaultCamera.setAttribute('camera');
         defaultCamera.setAttribute('wasd-controls');
         defaultCamera.setAttribute('look-controls');
         this.pendingElements++;


### PR DESCRIPTION
A bunch of small updates here to default camera position and geometry sizes. And then to all the examples so they match.

A few notes:
- Camera default FOV is no 80°. This is a close match to the FOV of the DK2, and ensures that 2D mode matches VR mode, leading to less layout discrepancies.
- Camera default position is now "0 1.8 4". Roughly standing height for adult male, and a reasonable 4 meters back. Geometry sizes have been reduced to match. These dimensions are more "human scale", and when combined with positional tracking (when we get #538 resolved), should give a nice parallax effect.
- Fog: something is buggy in our fog scene. 1) Some objects seem to be immune to the fog, and 2) the distribution of the fog seems to be almost a cube, based on the distribution against the spherical sky object. I tried to resolve these issues but didn't have much luck, and left as-is to highlight the issues.
- Visibility scene behavior seems to be a bit strange. Torus is very inconsistent in response to clicks, for example (you have to get close to it, even though the cursor distance is set to a more-than-adequate value of 100). I tried to dissect the issue but the JS is formidable and lacks any comments.
- Added new simplified Geometries scene, and renamed @ngokevin's existing scene to Geometries Gallery. Also resized and tweaked layout of that scene.
