### PR TITLE
With the refactoring of the setAttribute method the logic to update a…

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -7,7 +7,6 @@ var AComponents = require('./components').components;
 var ANode = require('./a-node');
 var debug = require('../utils/debug');
 var THREE = require('../../lib/three');
-var utils = require('../utils');
 
 var log = debug('core:a-entity');
 var error = debug('core:a-entity:error');
@@ -346,12 +345,9 @@ var proto = {
       var valueStr = value;
 
       if (component) {
-        partialComponentData = self.getAttribute(attr) || {};
-        if (typeof value === 'object') {
-          // Update currently-defined component data with the object.
-          value = utils.extend({}, partialComponentData, value);
-        } else if (typeof value === 'string' && componentAttrValue !== undefined) {
+        if (typeof value === 'string' && componentAttrValue !== undefined) {
           // Update currently-defined component data with the new attribute value.
+          partialComponentData = self.getAttribute(attr) || {};
           partialComponentData[value] = componentAttrValue;
           value = partialComponentData;
         }

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -188,16 +188,15 @@ suite('a-entity', function () {
       assert.equal(material.metalness, 0.75);
     });
 
-    test('can update a component with an object', function () {
+    test('can replace component attributes with an object', function () {
       var el = this.el;
       var material;
-      var value = { color: '#000', metalness: 0.75 };
+      var value = { color: '#000' };
       el.setAttribute('material', 'color: #F0F; roughness: 0.25');
       el.setAttribute('material', value);
       material = el.getAttribute('material');
       assert.equal(material.color, '#000');
-      assert.equal(material.roughness, 0.25);
-      assert.equal(material.metalness, 0.75);
+      assert.equal(material.roughness, undefined);
     });
 
     test('can set a single component via a single attribute', function () {


### PR DESCRIPTION
With the refactoring of the setAttribute method the logic to update component with an object has changed.

Before:

``` html
<a-entity material="color: red; roughness: 0.4; mettalic: 5"></a-entity>
```

``` javascript
el.setAttribute('material', { color: 'blue'});
```

Result:

``` html
<a-entity material="color: blue;"></a-entity>
```

Now:

``` html
<a-entity material="color: red; roughness: 0.4; mettalic: 5"></a-entity>
```

``` javascript
el.setAttribute('material', { color: 'red'});
```

Result:

``` html
<a-entity material="color: blue; roughness: 0.4; mettalic: 5"></a-entity>
```

I would expect setAttribute to set the whole attribute and not just update a part of it.
This patch reverts the logic to update the whole attribute.
