### PR TITLE
consistent geometry names (fixes #396)

### DIFF
--- a/examples/animation/index.html
+++ b/examples/animation/index.html
@@ -47,7 +47,7 @@
 
         <a-entity position="0 0 0">
           <a-animation mixin="orbit" dur="2000"></a-animation>
-          <a-entity geometry="primitive: torusKnot; radius: .5; tube: .05"
+          <a-entity geometry="primitive: torusKnot; radius: .5; radiusTubular: .05"
                     material="color: green" position="4 0 0">
             <a-animation attribute="geometry.p" direction="alternate" fill="forwards"
                          ease="linear"

--- a/examples/fog/index.html
+++ b/examples/fog/index.html
@@ -14,8 +14,8 @@
       <a-mixin id="move" attribute="position" direction="alternate" dur="4096"
                          fill="forwards" easing="linear" repeat="indefinite">
       </a-mixin>
-      <a-mixin id="box" geometry="primitive: torusKnot; p: 3; q: 11; tube: .5; radius: 10"
-                        material="color: #2F3C4F"></a-mixin>
+      <a-mixin id="box" geometry="primitive: torusKnot; p: 3; q: 11; radiusTubular: .5;
+                                  radius: 10" material="color: #2F3C4F"></a-mixin>
       <a-mixin id="spin" attribute="rotation" dur="4096" to="-360 0 0"
                          easing="linear" repeat="indefinite"></a-mixin>
     </a-assets>

--- a/examples/geometry-gallery/index.html
+++ b/examples/geometry-gallery/index.html
@@ -20,21 +20,20 @@
       </a-mixin>
       <a-mixin id="cylinder"
                geometry="primitive: cylinder; radius: 0.2; height: .5;
-                         segmentsRadius: 50; segmentsHeight: 50:
+                         segmentsRadial: 50; segmentsHeight: 50:
                          openEnded: true; thetaStart: 0; thetaEnd: 3">
       </a-mixin>
       <a-mixin id="ring"
-                geometry="primitive: ring; innerRadius: .3;
-                          openEnded: true; outerRadius: .5;
-                          segments: 50"></a-mixin>
+                geometry="primitive: ring; radiusInner: .3; openEnded: true; radiusOuter: .5;
+                          segmentsTheta: 50"></a-mixin>
       <a-mixin id="sphere"
                 geometry="primitive: sphere; radius: .1"></a-mixin>
       <a-mixin id="torus"
-                geometry="primitive: torus; arc: 6; radius: .3; tube: .05;
+                geometry="primitive: torus; arc: 6; radius: .3; radiusTubular: .05;
                           segments: 32; tubularSegments: 10;"></a-mixin>
       <a-mixin id="torus-knot"
                 geometry="primitive: torusKnot; p: 3; q: 7; radius: .25;
-                          segments: 32; tube: .07; tubularSegments: 10">
+                          segments: 32; radiusTubular: .07; segmentsTubular: 10">
       </a-mixin>
 
       <!-- Layout mixins. -->

--- a/examples/lights/index.html
+++ b/examples/lights/index.html
@@ -66,7 +66,7 @@
       obj.setAttribute('geometry', {
         primitive: 'torusKnot',
         radius: Math.random() * 10,
-        tube: 2,
+        radiusTubular: 2,
         p: Math.round(Math.random() * 10),
         q: Math.round(Math.random() * 10)
       });

--- a/examples/panoexplorer/index.html
+++ b/examples/panoexplorer/index.html
@@ -21,12 +21,11 @@
                                             width: 1.4; height: 1.4"
               sound="src: ../_sounds/click.ogg">
       </a-mixin>
-      <a-mixin id="cursor" geometry="primitive: ring; outerRadius: 0.20;
-                                     innerRadius: 0.14"
+      <a-mixin id="cursor" geometry="primitive: ring; radiusOuter: 0.20; radiusInner: 0.14"
                material="color: gray" cursor></a-mixin>
       <a-mixin id="cursor-hovering" material="color: springgreen"></a-mixin>
-      <a-mixin id="click-animation" begin="click" easing="ease-in" attribute="scale" fill="backwards"
-               from="0.1 0.1 0.1" to="1 1 1" dur="150"></a-animation>
+      <a-mixin id="click-animation" begin="click" easing="ease-in" attribute="scale"
+               fill="backwards" from="0.1 0.1 0.1" to="1 1 1" dur="150"></a-animation>
       <a-mixin id="fuse-animation" begin="fusing" easing="ease-in" attribute="scale"
                fill="forwards" from="1 1 1" to="0.1 0.1 0.1" dur="1500"></a-mixin>
     </a-asset>

--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -10,31 +10,37 @@ var warn = debug('components:geometry:warn');
 /**
  * Geometry component. Combined with material component to make a mesh in 3D object.
  *
- * TODO: rename component attributes to be consistent with three.js parameters
- *       names is exposed in object3D.geometry.parameters.
- *
- * @param {number} [arc=2 * PI]
- * @param {number} depth
- * @param {number} height
- * @param {number} innerRadius
- * @param {bool} openEnded
- * @param {number} outerRadius
- * @param {number} [p=2] - Coprime of q that helps define torus knot.
- * @param {number} [primitive=null] - Type of shape (e.g., box, sphere).
- * @param {number} [q=3] - Coprime of p that helps define torus knot.
- * @param {number} radius
- * @param {number} segments
- * @param {number} segmentsHeight
- * @param {number} segmentsRadius
- * @param {number} segmentsWidth
- * @param {number} thetaLength
- * @param {number} thetaStart
+ * @param {number} [arc=2 * PI] -
+ *   Used by torus. A central angle that determines arc length of the torus.
+ * @param {number} [depth=2] - Used by box. Depth of the sides on the Z axis.
+ * @param {number} [height=2] -
+ *   Used by box, cylinder, plane. Height of the sides on the Y axis.
+ * @param {bool} [openEnded=false] - Used by cylinder.
+ * @param {number} [p=2] - Used by torusKnot. Coprime of q.
+ * @param {number} [primitive=null] - type of shape (e.g., box, sphere).
+ * @param {number} [q=3] - Used by torusKnot. Coprime of p.
+ * @param {number} [radius=1] - Used by circle, cylinder, ring, sphere, torus, torusKnot.
+ * @param {number} [radiusBottom=1] - Used by cylinder.
+ * @param {number} [radiusInner=0.8] - Used by ring.
+ * @param {number} [radiusOuter=1.2] - Used by ring.
+ * @param {number} [radiusTop=1] - Used by cylinder.
+ * @param {number} [radiusTube=0.2] - Used by torus. Tube radius.
+ * @param {number} [scaleHeight=1] - Used by torusKnot.
+ * @param {number} [segments] - Used by circle. Number of segments.
+ * @param {number} [segmentsHeight=18] - Used by cylinder, sphere. Number of segments.
+ * @param {number} [segmentsPhi=8] - Used by ring.
+ * @param {number} [segmentsRadial=36] - Used by cylinder. Number of segments.
+ * @param {number} [segmentsTheta=8] -
+ *   Used by ring. Number of segments. A higher number means the ring will be more round.
+ *   Minimum is 3.
+ * @param {number} [segmentsTubular=8] - Used by torus, torusKnot. Number of segments.
+ * @param {number} [segmentsWidth=36] - Used by sphere.
+ * @param {number} [thetaLength=2 * PI] - Used by circle, cylinder, ring.
+ * @param {number} [thetaStart=0] - Used by circle, cylinder, ring.
  * @param {string} translate -
  *   Defined as a coordinate (e.g., `-1 0 5`) that translates geometry vertices. Useful for
  *   effectively changing the pivot point.
- * @param {number} tube
- * @param {number} tubularSegments
- * @param {number} width
+ * @param {number} [width=2] - Used by box, plane.
  */
 module.exports.Component = registerComponent('geometry', {
   defaults: {
@@ -42,24 +48,27 @@ module.exports.Component = registerComponent('geometry', {
       arc: 2 * Math.PI,
       depth: 2,
       height: 2,
-      innerRadius: 0.8,
       openEnded: false,
-      outerRadius: 1.2,
       p: 2,
       translate: { x: 0, y: 0, z: 0 },
       primitive: '',
       q: 3,
       radius: DEFAULT_RADIUS,
-      radiusTop: DEFAULT_RADIUS,
       radiusBottom: DEFAULT_RADIUS,
-      segments: 32,
+      radiusInner: 0.8,
+      radiusOuter: 1.2,
+      radiusTop: DEFAULT_RADIUS,
+      radiusTubular: 0.2,
+      scaleHeight: 1,
+      segments: 8,
       segmentsHeight: 18,
-      segmentsRadius: 36,
+      segmentsPhi: 8,
+      segmentsRadial: 36,
+      segmentsTheta: 8,
+      segmentsTubular: 8,
       segmentsWidth: 36,
       thetaLength: 6.3,
       thetaStart: 0,
-      tube: 0.2,
-      tubularSegments: 8,
       width: 2
     }
   },
@@ -79,7 +88,7 @@ module.exports.Component = registerComponent('geometry', {
       var translateNeedsUpdate = !utils.deepEqual(data.translate, currentTranslate);
 
       if (geometryNeedsUpdate) {
-        geometry = this.el.object3D.geometry = this.getGeometry();
+        geometry = this.el.object3D.geometry = getGeometry(this.data, this.defaults);
       }
       if (translateNeedsUpdate) {
         applyTranslate(geometry, data.translate, currentTranslate);
@@ -94,68 +103,68 @@ module.exports.Component = registerComponent('geometry', {
     value: function () {
       this.el.object3D.geometry = null;
     }
-  },
-
-  /**
-   * @returns {object} geometry
-   */
-  getGeometry: {
-    value: function () {
-      var data = this.data;
-      var defaults = this.defaults;
-      var radiusBottom;
-      var radiusTop;
-
-      switch (data.primitive) {
-        case 'box': {
-          return new THREE.BoxGeometry(data.width, data.height, data.depth);
-        }
-        case 'circle': {
-          return new THREE.CircleGeometry(
-            data.radius, data.segments, data.thetaStart, data.thetaLength);
-        }
-        case 'cylinder': {
-          // Shortcut for specifying both top and bottom radius.
-          radiusTop = data.radius;
-          radiusBottom = data.radius;
-          if (data.radius === defaults.radius) {
-            radiusTop = data.radiusTop;
-            radiusBottom = data.radiusBottom;
-          }
-          return new THREE.CylinderGeometry(
-            radiusTop, radiusBottom, data.height, data.segmentsRadius,
-            data.segmentsHeight, data.openEnded, data.thetaStart,
-            data.thetaLength);
-        }
-        case 'plane': {
-          return new THREE.PlaneBufferGeometry(data.width, data.height);
-        }
-        case 'ring': {
-          return new THREE.RingGeometry(
-            data.innerRadius, data.outerRadius, data.segments);
-        }
-        case 'sphere': {
-          return new THREE.SphereGeometry(
-            data.radius, data.segmentsWidth, data.segmentsHeight);
-        }
-        case 'torus': {
-          return new THREE.TorusGeometry(
-            data.radius, data.tube, data.segments, data.tubularSegments,
-            data.arc);
-        }
-        case 'torusKnot': {
-          return new THREE.TorusKnotGeometry(
-            data.radius, data.tube, data.segments, data.tubularSegments,
-            data.p, data.q);
-        }
-        default: {
-          warn('Primitive type not supported: ' + data.primitive);
-          return new THREE.Geometry();
-        }
-      }
-    }
   }
 });
+
+/**
+ * Creates a three.js geometry.
+ *
+ * @param {object} data
+ * @param {object} defaults
+ * @returns {object} geometry
+ */
+function getGeometry (data, defaults) {
+  var radiusBottom;
+  var radiusTop;
+
+  switch (data.primitive) {
+    case 'box': {
+      return new THREE.BoxGeometry(data.width, data.height, data.depth);
+    }
+    case 'circle': {
+      return new THREE.CircleGeometry(
+        data.radius, data.segments, data.thetaStart, data.thetaLength);
+    }
+    case 'cylinder': {
+      // Shortcut for specifying both top and bottom radius.
+      radiusTop = data.radius;
+      radiusBottom = data.radius;
+      if (data.radius === defaults.radius) {
+        radiusTop = data.radiusTop;
+        radiusBottom = data.radiusBottom;
+      }
+      return new THREE.CylinderGeometry(
+        radiusTop, radiusBottom, data.height, data.segmentsRadial, data.segmentsHeight,
+        data.openEnded, data.thetaStart, data.thetaLength);
+    }
+    case 'plane': {
+      return new THREE.PlaneBufferGeometry(data.width, data.height);
+    }
+    case 'ring': {
+      return new THREE.RingGeometry(
+        data.radiusInner, data.radiusOuter, data.segmentsTheta, data.segmentsPhi,
+        data.thetaStart, data.thetaLength);
+    }
+    case 'sphere': {
+      return new THREE.SphereGeometry(
+        data.radius, data.segmentsWidth, data.segmentsHeight);
+    }
+    case 'torus': {
+      return new THREE.TorusGeometry(
+        data.radius, data.radiusTubular * 2, data.segmentsRadial, data.segmentsTubular,
+        data.arc);
+    }
+    case 'torusKnot': {
+      return new THREE.TorusKnotGeometry(
+        data.radius, data.radiusTubular * 2, data.segmentsRadial, data.segmentsTubular,
+        data.p, data.q, data.scaleHeight);
+    }
+    default: {
+      warn('Primitive type not supported: ' + data.primitive);
+      return new THREE.Geometry();
+    }
+  }
+}
 
 /**
  * Translates geometry vertices.

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -52,10 +52,9 @@ suite('geometry', function () {
     test('creates circle geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute(
-        'geometry',
-        'primitive: circle; radius: 5; segments: 4; thetaStart: 1; ' +
-        'thetaLength: 2');
+      el.setAttribute('geometry', {
+        primitive: 'circle', radius: 5, segments: 4, thetaStart: 1, thetaLength: 2
+      });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'CircleGeometry');
       assert.equal(geometry.parameters.radius, 5);
@@ -67,10 +66,10 @@ suite('geometry', function () {
     test('creates cylinder geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute(
-        'geometry',
-        'primitive: cylinder; radius: 1; height: 2; segmentsRadius: 3; ' +
-        'segmentsHeight: 4; openEnded: true; thetaStart: 3.1; thetaLength: 6');
+      el.setAttribute('geometry', {
+        primitive: 'cylinder', radius: 1, height: 2, segmentsRadial: 3, segmentsHeight: 4,
+        openEnded: true, thetaStart: 3.1, thetaLength: 6
+      });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'CylinderGeometry');
       assert.equal(geometry.parameters.radiusBottom, 1);
@@ -86,7 +85,7 @@ suite('geometry', function () {
     test('creates cylinder geometry with radius shortcut', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute('geometry', 'primitive: cylinder; radius: 8');
+      el.setAttribute('geometry', { primitive: 'cylinder', radius: 8 });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'CylinderGeometry');
       assert.equal(geometry.parameters.radiusTop, 8);
@@ -96,7 +95,7 @@ suite('geometry', function () {
     test('creates plane geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute('geometry', 'primitive: plane; width: 1; height: 2');
+      el.setAttribute('geometry', { primitive: 'plane', width: 1, height: 2 });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'PlaneBufferGeometry');
       assert.equal(geometry.parameters.width, 1);
@@ -106,8 +105,8 @@ suite('geometry', function () {
     test('creates ring geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute('geometry', 'primitive: ring; innerRadius: 1; ' +
-                      'outerRadius: 2; segments: 3');
+      el.setAttribute('geometry', {
+        primitive: 'ring', radiusInner: 1, radiusOuter: 2, segmentsTheta: 3});
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'RingGeometry');
       assert.equal(geometry.parameters.innerRadius, 1);
@@ -118,8 +117,9 @@ suite('geometry', function () {
     test('creates sphere geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute('geometry', 'primitive: sphere; radius: 1; ' +
-                      'segmentsWidth: 2; segmentsHeight: 3');
+      el.setAttribute('geometry', {
+        primitive: 'sphere', radius: 1, segmentsWidth: 2, segmentsHeight: 3
+      });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'SphereGeometry');
       assert.equal(geometry.parameters.radius, 1);
@@ -130,13 +130,15 @@ suite('geometry', function () {
     test('creates torus geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute('geometry', 'primitive: torus; radius: 1; ' +
-                      'tube: 2; segments: 3; tubularSegments: 4; arc: 5.1');
+      el.setAttribute('geometry', {
+        primitive: 'torus', radius: 1, radiusTubular: 2, segmentsRadial: 3, segmentsTubular: 4,
+        arc: 5.1
+      });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'TorusGeometry');
       assert.equal(geometry.parameters.radius, 1);
-      assert.equal(geometry.parameters.tube, 2);
       assert.equal(geometry.parameters.radialSegments, 3);
+      assert.equal(geometry.parameters.tube, 4);
       assert.equal(geometry.parameters.tubularSegments, 4);
       assert.equal(geometry.parameters.arc, 5.1);
     });
@@ -144,12 +146,14 @@ suite('geometry', function () {
     test('creates torus knot geometry', function () {
       var el = this.el;
       var geometry;
-      el.setAttribute('geometry', 'primitive: torusKnot; radius: 1; ' +
-                      'tube: 2; segments: 3; tubularSegments: 4; p: 5; q: 6');
+      el.setAttribute('geometry', {
+        primitive: 'torusKnot', radius: 1, radiusTubular: 2, segmentsRadial: 3,
+        segmentsTubular: 4, p: 5, q: 6
+      });
       geometry = el.object3D.geometry;
       assert.equal(geometry.type, 'TorusKnotGeometry');
       assert.equal(geometry.parameters.radius, 1);
-      assert.equal(geometry.parameters.tube, 2);
+      assert.equal(geometry.parameters.tube, 4);
       assert.equal(geometry.parameters.radialSegments, 3);
       assert.equal(geometry.parameters.tubularSegments, 4);
       assert.equal(geometry.parameters.p, 5);


### PR DESCRIPTION
I changed my mind. Thought about making parameters consistent with three.js, but three.js is not consistent with itself, and they could change any time since they're just in src/extras. So it's better we take it upon ourselves to make the names consistent.
- segmentsRadius => segmentsRadial
- tubularSegments => segmentsTubular
- innerRadius => radiusInner
- outerRadius => radiusOuter
- tube => radiusTubular
- Add scaleHeight, segmentsPhi, segmentsTheta.
- JSDoc a tiny bit more geometries

https://github.com/MozVR/aframe/pull/252
