### PR TITLE
improve scene onload animations by factoring in loading time to tween

### DIFF
--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -22,6 +22,7 @@ var registerElement = re.registerElement;
  * @member {object} cameraEl - Set the entity with a camera component.
  * @member {object} canvas
  * @member {bool} defaultLightsEnabled - false if user has not added lights.
+ * @member {number} initialTime
  * @member {bool} insideIframe
  * @member {bool} insideLoader
  * @member {bool} isScene - Differentiates this as a scene entity as opposed
@@ -44,6 +45,7 @@ var AScene = module.exports = registerElement('a-scene', {
       value: function () {
         this.behaviors = [];
         this.defaultLightsEnabled = true;
+        this.initialTime = 0;
         this.insideIframe = window.top !== window.self;
         this.insideLoader = false;
         this.isScene = true;
@@ -221,8 +223,10 @@ var AScene = module.exports = registerElement('a-scene', {
           return;
         }
         this.resizeCanvas();
-        // Kick off the render loop.
-        this.render(performance.now());
+
+        // Kick off render loop.
+        this.initialTime = performance.now();
+        this.render(this.initialTime);
         this.renderLoopStarted = true;
         this.load();
       }
@@ -625,7 +629,7 @@ var AScene = module.exports = registerElement('a-scene', {
           stats('rAF').tick();
           stats('FPS').frame();
         }
-        TWEEN.update(t);
+        TWEEN.update(t - this.initialTime);
         this.behaviors.forEach(function (behavior) {
           behavior.update();
         });

--- a/style/rStats.css
+++ b/style/rStats.css
@@ -28,31 +28,43 @@
 }
 
 .rs-group {
+  display: -webkit-box;
+  display: -webkit-flex;
   display: flex;
+  -webkit-flex-direction: column-reverse;
   flex-direction: column-reverse;
 }
 
 .rs-counter-base {
   align-items: center;
+  display: -webkit-box;
+  display: -webkit-flex;
   display: flex;
   height: 10px;
+  -webkit-justify-content: space-between;
   justify-content: space-between;
   margin: 2px 0;
 }
 
 .rs-counter-id {
   font-weight: 300;
+  -webkit-box-ordinal-group: 0;
+  -webkit-order: 0;
   order: 0;
 }
 
 .rs-counter-value {
   font-weight: 300;
+  -webkit-box-ordinal-group: 1;
+  -webkit-order: 1;
   order: 1;
   text-align: right;
   width: 25px;
 }
 
 .rs-canvas {
+  -webkit-box-ordinal-group: 2;
+  -webkit-order: 2;
   order: 2;
 }
 


### PR DESCRIPTION
In Firefox + Chrome, I found this fixes animations that are imperatively fired immediately on scene load.

Before, the fade was not visible and the transition was instant and sudden.

After, the fade was visible.
