### PR TITLE
fix parent.add <a-root> error for aframe

### DIFF
--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -147,7 +147,9 @@ var proto = {
       function attach () {
         // To prevent an object to attach itself multiple times to the parent.
         self.attachedToParent = true;
-        parent.add(self);
+        if (parent.add) {
+          parent.add(self);
+        }
       }
     }
   },


### PR DESCRIPTION
not sure if this belongs in core. hopefully new template system will prevent need to do this, but keep this here for now in case we need it later
