### PR TITLE
default sound autoplay to true

### DIFF
--- a/src/components/sound.js
+++ b/src/components/sound.js
@@ -16,7 +16,7 @@ var warn = debug('components:sound:warn');
 module.exports.Component = registerComponent('sound', {
   defaults: {
     value: {
-      autoplay: false,
+      autoplay: true,
       on: 'click',
       loop: false,
       volume: 1


### PR DESCRIPTION
I'm not 100% sure on this so need some advice.

Should we default sound component to autoplay? I'm worried that users will try to set the sound component in markup and wonder why they're not hearing anything.
