### PR TITLE
When removing geometry or material components we should not set geome…

### DIFF
--- a/src/components/geometry.js
+++ b/src/components/geometry.js
@@ -102,7 +102,7 @@ module.exports.Component = registerComponent('geometry', {
    */
   remove: {
     value: function () {
-      this.el.object3D.geometry = null;
+      this.el.object3D.geometry = new THREE.Geometry();
     }
   }
 });

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -101,8 +101,10 @@ module.exports.Component = registerComponent('material', {
   remove: {
     value: function () {
       var el = this.el;
+      var defaultColor = this.defaults.color;
+      var defaultMaterial = new THREE.MeshBasicMaterial({ color: defaultColor });
       var object3D = el.object3D;
-      if (object3D) { object3D.material = null; }
+      if (object3D) { object3D.material = defaultMaterial; }
       el.sceneEl.unregisterMaterial(this.material);
     }
   },

--- a/tests/components/geometry.test.js
+++ b/tests/components/geometry.test.js
@@ -44,7 +44,7 @@ suite('geometry', function () {
       test('removes geometry', function () {
         var el = this.el;
         el.removeAttribute('geometry');
-        assert.equal(el.object3D.geometry, null);
+        assert.equal(el.object3D.geometry.type, 'Geometry');
       });
     });
   });

--- a/tests/components/material.test.js
+++ b/tests/components/material.test.js
@@ -68,7 +68,7 @@ suite('material', function () {
       var el = this.el;
       assert.ok(el.object3D.material);
       el.removeAttribute('material');
-      assert.notOk(el.object3D.material);
+      assert.equal(el.object3D.material.type, 'MeshBasicMaterial');
     });
   });
 


### PR DESCRIPTION
…try or material to null on the THREE.js Object3D because it creates and ill formed THREE.Mesh and the renderer complains (fixes #610)
