### PR TITLE
tweak styles for "Enter VR" icon

### DIFF
--- a/style/aframe-core.css
+++ b/style/aframe-core.css
@@ -33,30 +33,23 @@ a-scene img {
 }
 
 .a-enter-vr-button {
-  background: url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%0D%0A%3C%21--%20Generator%3A%20Adobe%20Illustrator%2018.0.0%2C%20SVG%20Export%20Plug-In%20.%20SVG%20Version%3A%206.00%20Build%200%29%20%20--%3E%0D%0A%3C%21DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%0D%0A%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%0D%0A%09%20viewBox%3D%225596.6%20-116.5%20599.8%20599.8%22%20enable-background%3D%22new%205596.6%20-116.5%20599.8%20599.8%22%20xml%3Aspace%3D%22preserve%22%3E%0D%0A%3Crect%20x%3D%225596.6%22%20y%3D%22-116.5%22%20fill%3D%22none%22%20width%3D%22599.8%22%20height%3D%22599.8%22%2F%3E%0D%0A%3Cpath%20id%3D%22goggles%22%20fill%3D%22%23FFFFFF%22%20d%3D%22M6152.1%2C145.5h-37.4v-33.4c-1.1-27.4-21.3-48.2-48.7-48.2h-166.5h-166%0D%0A%09c-27.4%2C0-47.7%2C20.8-47.7%2C48.2v33.4h-37.7v69h37.7v36.7c0%2C27.4%2C20.3%2C52%2C47.7%2C52h126c3.8%2C0%2C7.1-3.3%2C9.3-6l20.3-34%0D%0A%09c5.5-6.6%2C15.9-7.1%2C21.9-0.5l20.3%2C34.5c2.2%2C3.3%2C5.5%2C6%2C9.3%2C6h126c27.4%2C0%2C48.2-24.6%2C48.2-52v-36.7h37.4V145.5L6152.1%2C145.5z%0D%0A%09%20M5806.3%2C261.6c-44.4%2C0-80-35.6-80-80s35.6-80%2C80-80s80%2C35.6%2C80%2C80S5850.1%2C261.6%2C5806.3%2C261.6z%20M5993.1%2C261.6c-44.4%2C0-80-35.6-80-80%0D%0A%09s35.6-80%2C80-80s80%2C35.6%2C80%2C80S6036.9%2C261.6%2C5993.1%2C261.6z%22%2F%3E%0D%0A%3C%2Fsvg%3E%0D%0A) #333 50% 50% / 64px no-repeat;
-  border: 2px solid #FFF;
-  border-radius: 5px;
+  background: rgba(0,0,0,0.35) url(data:image/svg+xml,%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22utf-8%22%3F%3E%0D%0A%3C%21--%20Generator%3A%20Adobe%20Illustrator%2018.0.0%2C%20SVG%20Export%20Plug-In%20.%20SVG%20Version%3A%206.00%20Build%200%29%20%20--%3E%0D%0A%3C%21DOCTYPE%20svg%20PUBLIC%20%22-%2F%2FW3C%2F%2FDTD%20SVG%201.1%2F%2FEN%22%20%22http%3A%2F%2Fwww.w3.org%2FGraphics%2FSVG%2F1.1%2FDTD%2Fsvg11.dtd%22%3E%0D%0A%3Csvg%20version%3D%221.1%22%20id%3D%22Layer_1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20x%3D%220px%22%20y%3D%220px%22%0D%0A%09%20viewBox%3D%225596.6%20-116.5%20599.8%20599.8%22%20enable-background%3D%22new%205596.6%20-116.5%20599.8%20599.8%22%20xml%3Aspace%3D%22preserve%22%3E%0D%0A%3Crect%20x%3D%225596.6%22%20y%3D%22-116.5%22%20fill%3D%22none%22%20width%3D%22599.8%22%20height%3D%22599.8%22%2F%3E%0D%0A%3Cpath%20id%3D%22goggles%22%20fill%3D%22%23FFFFFF%22%20d%3D%22M6152.1%2C145.5h-37.4v-33.4c-1.1-27.4-21.3-48.2-48.7-48.2h-166.5h-166%0D%0A%09c-27.4%2C0-47.7%2C20.8-47.7%2C48.2v33.4h-37.7v69h37.7v36.7c0%2C27.4%2C20.3%2C52%2C47.7%2C52h126c3.8%2C0%2C7.1-3.3%2C9.3-6l20.3-34%0D%0A%09c5.5-6.6%2C15.9-7.1%2C21.9-0.5l20.3%2C34.5c2.2%2C3.3%2C5.5%2C6%2C9.3%2C6h126c27.4%2C0%2C48.2-24.6%2C48.2-52v-36.7h37.4V145.5L6152.1%2C145.5z%0D%0A%09%20M5806.3%2C261.6c-44.4%2C0-80-35.6-80-80s35.6-80%2C80-80s80%2C35.6%2C80%2C80S5850.1%2C261.6%2C5806.3%2C261.6z%20M5993.1%2C261.6c-44.4%2C0-80-35.6-80-80%0D%0A%09s35.6-80%2C80-80s80%2C35.6%2C80%2C80S6036.9%2C261.6%2C5993.1%2C261.6z%22%2F%3E%0D%0A%3C%2Fsvg%3E%0D%0A) 50% 0 no-repeat;
+  background-size: auto 100%;
+  border: 0;
   color: #FFF;
   cursor: pointer;
-  height: 72px;
+  height: 50px;
   position: fixed;
-  right: 5px;
-  bottom: 5px;
+  right: 20px;
+  bottom: 20px;
   transition: background .1s ease;
   -moz-transition: background .1s ease;
   -webkit-transition: background .1s ease;
-  width: 64px;
+  width: 60px;
   z-index: 999999;
 }
 
 .a-enter-vr-button:active,
 .a-enter-vr-button:hover {
   background-color: #EF2D5E;
-}
-
-@media (min-width: 480px) {
-  .a-enter-vr-button {
-    right: 10px;
-    top: 10px;
-  }
 }


### PR DESCRIPTION
gets the icon closer to that in @jcarpenter's mockup:

![image](https://cloud.githubusercontent.com/assets/203725/11668928/e14d48b4-9dc7-11e5-8e4b-2ef437f12254.png)

<hr>
## before

![image](https://cloud.githubusercontent.com/assets/203725/11668990/3e766ff2-9dc8-11e5-9dea-2612c6530c1d.png)
![image](https://cloud.githubusercontent.com/assets/203725/11668997/4248a9ec-9dc8-11e5-99e6-34a9ac7fa3fa.png)
## after

![image](https://cloud.githubusercontent.com/assets/203725/11669008/4c20b81a-9dc8-11e5-99fa-04e88a37c4bb.png)
![image](https://cloud.githubusercontent.com/assets/203725/11669015/4f8945f8-9dc8-11e5-9618-36c330a040b3.png)
