### PR TITLE
Polyfill promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "dependencies": {
     "debug": "^2.2.0",
     "document-register-element": "^0.5.2",
+    "es6-promise": "^3.0.2",
     "object-assign": "^4.0.1",
+    "present": "0.0.6",
     "request-interval": "^1.0.0",
     "style-attr": "^1.0.1",
     "three-dev": "0.74.0-beta3",

--- a/src/aframe-core.js
+++ b/src/aframe-core.js
@@ -1,3 +1,6 @@
+require('es6-promise').polyfill();  // Polyfill `Promise`.
+require('present');  // Polyfill `performance.now()`.
+
 require('../style/aframe-core.css');
 require('../style/rStats.css');
 var debug = require('./utils/debug');


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/203725/11676847/0fe001c0-9e05-11e5-8c06-4344c0b59e4e.png)

smallest libraries I could find. the [`es6-promise`](https://github.com/jakearchibald/es6-promise) is super legit. and the [`present`](https://github.com/dbkaplun/present) one is tiny and works.
