### PR TITLE
Fixed positional tracking with multiple cameras

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -17,6 +17,8 @@ module.exports.Component = registerComponent('look-controls', {
     this.setupHMDControls();
     this.attachEventListeners();
     scene.addBehavior(this);
+    this.previousPosition = new THREE.Vector3();
+    this.deltaPosition = new THREE.Vector3();
   },
 
   setupMouseControls: function () {
@@ -105,17 +107,15 @@ module.exports.Component = registerComponent('look-controls', {
     };
   })(),
 
-  calculateDeltaPosition: (function () {
-    var previousPosition = new THREE.Vector3();
-    var deltaPosition = new THREE.Vector3();
-    return function () {
-      var dolly = this.dolly;
-      deltaPosition.copy(dolly.position);
-      deltaPosition.sub(previousPosition);
-      previousPosition.copy(dolly.position);
-      return deltaPosition;
-    };
-  })(),
+  calculateDeltaPosition: function () {
+    var dolly = this.dolly;
+    var deltaPosition = this.deltaPosition;
+    var previousPosition = this.previousPosition;
+    deltaPosition.copy(dolly.position);
+    deltaPosition.sub(previousPosition);
+    previousPosition.copy(dolly.position);
+    return deltaPosition;
+  },
 
   updateHMDQuaternion: (function () {
     var hmdQuaternion = new THREE.Quaternion();


### PR DESCRIPTION
The current positional code uses a global delta that in the case of having more than one camera it gives a correct value for the first one, the next cameras will get delta=0 that's why having multiple cameras on the scene will make the positional tracking to stop working.
Every scene having just `a-camera` template will have two cameras as the default will be created due to the delay until the camera template is currently loaded.
