### PR TITLE
Releases orientation lock

### DIFF
--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -147,8 +147,8 @@ module.exports.Component = registerComponent('look-controls', {
 
     if (!this.mouseDown || !this.data.enabled) { return; }
 
-    var movementX = event.movementX || event.mozMovementX || event.webkitMovementX;
-    var movementY = event.movementY || event.mozMovementY || event.webkitMovementY;
+    var movementX = event.movementX || event.mozMovementX;
+    var movementY = event.movementY || event.mozMovementY;
 
     if (movementX === undefined || movementY === undefined) {
       movementX = event.screenX - previousMouseEvent.screenX;

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -165,6 +165,8 @@ var AScene = module.exports = registerElement('a-scene', {
           // Lock to landscape orientation on mobile.
           if (fsElement && this.isMobile) {
             window.screen.orientation.lock('landscape');
+          } else {
+            window.screen.orientation.unlock();
           }
           if (!fsElement) {
             this.showUI();


### PR DESCRIPTION
Fixes issue where orientation is locked to landscape after exiting VR (by pressing back button on Android)
