### PR TITLE
Release orientation lock

### DIFF
--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -165,6 +165,8 @@ var AScene = module.exports = registerElement('a-scene', {
           // Lock to landscape orientation on mobile.
           if (fsElement && this.isMobile) {
             window.screen.orientation.lock('landscape');
+          } else {
+            window.screen.orientation.unlock();
           }
           if (!fsElement) {
             this.showUI();


### PR DESCRIPTION
Fixes issue with orientation lock not releasing after pressing Back button to Exit VR on mobile Chrome.
