### PR TITLE
have entities wait for child entities to load before emitting load

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -16,7 +16,7 @@ module.exports.Component = registerComponent('camera', {
     var camera = this.camera = new THREE.PerspectiveCamera();
     var el = this.el;
     el.object3D.add(camera);
-    el.sceneEl.cameraEl = el;
+    el.sceneEl.registerCamera(el);
   },
 
   /**

--- a/src/components/look-at.js
+++ b/src/components/look-at.js
@@ -58,7 +58,7 @@ module.exports.Component = registerComponent('look-at', {
         warn('"' + targetSelector + '" does not point to a valid entity to look-at');
         return;
       }
-      if (!targetEl.object3D) {
+      if (!targetEl.hasLoaded) {
         return targetEl.addEventListener('loaded', function () {
           self.beginTracking(targetEl);
         });

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -72,7 +72,11 @@ module.exports.AAnimation = registerElement('a-animation', {
         var el = self.el = self.parentNode;
 
         if (el.isNode) {
-          init();
+          if (el.hasLoaded) {
+            init();
+          } else {
+            el.addEventListener('loaded', init.bind(self));
+          }
         } else {
           // To handle elements that are not yet `<a-entity>`s (e.g., templates).
           el.addEventListener('nodeready', init.bind(self));

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -1,67 +1,16 @@
-/* global HTMLElement */
-var re = require('./a-register-element');
-var utils = require('../utils/');
-
-var isNode = re.isNode;
+var ANode = require('./a-node');
+var re = require('../a-register-element');
 var registerElement = re.registerElement;
 
-module.exports = registerElement(
-  'a-assets',
-  {
-    prototype: Object.create(
-      HTMLElement.prototype,
-      {
-        attachedCallback: {
-          value: function () {
-            this.attachEventListeners();
-          }
-        },
-
-        attachEventListeners: {
-          value: function () {
-            var self = this;
-            var assetLoaded = this.assetLoaded.bind(this);
-            this.assetsPending = 0;
-            var children = this.querySelectorAll('*');
-            Array.prototype.slice.call(children).forEach(countElement);
-
-            if (!this.assetsPending) {
-              assetLoaded();
-            }
-
-            function countElement (node) {
-              if (!isNode(node)) { return; }
-              if (!node.hasLoaded) {
-                attachEventListener(node);
-                self.assetsPending++;
-              }
-            }
-
-            function attachEventListener (node) {
-              node.addEventListener('loaded', assetLoaded);
-            }
-          }
-        },
-
-        assetLoaded: {
-          value: function () {
-            this.assetsPending--;
-            if (this.assetsPending <= 0) {
-              this.load();
-            }
-          }
-        },
-
-        load: {
-          value: function () {
-            // To prevent emitting the loaded event more than once.
-            if (this.hasLoaded) { return; }
-            this.hasLoaded = true;
-            var data = { bubbles: false, detail: {} };
-            utils.fireEvent(this, 'loaded', data);
-          }
-        }
+/**
+ * TODO: Block on assets before loading.
+ */
+module.exports = registerElement('a-assets', {
+  prototype: Object.create(ANode.prototype, {
+    load: {
+      value: function () {
+        ANode.prototype.load.call(this);
       }
-    )
-  }
-);
+    }
+  })
+});

--- a/src/core/a-assets.js
+++ b/src/core/a-assets.js
@@ -1,6 +1,5 @@
 var ANode = require('./a-node');
-var re = require('../a-register-element');
-var registerElement = re.registerElement;
+var registerElement = require('./a-register-element').registerElement;
 
 /**
  * TODO: Block on assets before loading.

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -10,6 +10,8 @@ var log = debug('core:a-entity');
 var error = debug('core:a-entity:error');
 var registerElement = re.registerElement;
 
+var AEntity;
+
 /**
  * Entity element definition.
  * Entities represent all elements that are part of the scene, and always have
@@ -25,7 +27,7 @@ var registerElement = re.registerElement;
  * @member {object} object3D - three.js object.
  * @member {array} states
  */
-var proto = {
+var proto = Object.create(ANode.prototype, {
   defaults: {
     value: {
       position: '',
@@ -80,25 +82,6 @@ var proto = {
         return;
       }
       this.updateComponent(attr, attrValue);
-    }
-  },
-
-  /**
-   * @returns {array} Direct children that are entities.
-   */
-  getChildEntities: {
-    value: function () {
-      var children = this.children;
-      var childEntities = [];
-
-      for (var i = 0; i < this.children.length; i++) {
-        var child = children[i];
-        if (child.tagName === this.tagName) {
-          childEntities.push(child);
-        }
-      }
-
-      return childEntities;
     }
   },
 
@@ -196,6 +179,25 @@ var proto = {
   remove: {
     value: function (el) {
       this.object3D.remove(el.object3D);
+    }
+  },
+
+  /**
+   * @returns {array} Direct children that are entities.
+   */
+  getChildEntities: {
+    value: function () {
+      var children = this.children;
+      var childEntities = [];
+
+      for (var i = 0; i < this.children.length; i++) {
+        var child = children[i];
+        if (child instanceof AEntity) {
+          childEntities.push(child);
+        }
+      }
+
+      return childEntities;
     }
   },
 
@@ -489,8 +491,9 @@ var proto = {
       return is;
     }
   }
-};
-
-module.exports = registerElement('a-entity', {
-  prototype: Object.create(ANode.prototype, proto)
 });
+
+AEntity = registerElement('a-entity', {
+  prototype: proto
+});
+module.exports = AEntity;

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -91,7 +91,7 @@ var proto = {
 
       for (var i = 0; i < this.children.length; i++) {
         var child = children[i];
-        if (child.isEntity) {
+        if (child.tagName === this.tagName) {
           childEntities.push(child);
         }
       }
@@ -174,19 +174,19 @@ var proto = {
   },
 
   load: {
-    value: function (childFilter) {
-      // To prevent calling load more than once
+    value: function () {
       if (this.hasLoaded) { return; }
-      // Handle to the associated DOM element
       this.object3D.el = this;
-      // It attaches itself to the threejs parent object3D
+
+      // Attach to parent object3D.
       this.addToParent();
-      // Components initialization
-      this.updateComponents();
-      // Call the parent class
-      ANode.prototype.load.call(this, childFilter || function (el) {
-        return el.isEntity;
-      });
+
+      if (this.isScene) {
+        ANode.prototype.load.call(this, this.updateComponents.bind(this));
+      } else {
+        ANode.prototype.load.call(this, this.updateComponents.bind(this),
+                                  function (el) { return el.isEntity; });
+      }
     },
     writable: window.debug
   },

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -53,7 +53,9 @@ var proto = {
   attachedCallback: {
     value: function () {
       this.addToParent();
-      this.load();
+      if (!this.isScene) {
+        this.load();
+      }
     }
   },
 

--- a/src/core/a-entity.js
+++ b/src/core/a-entity.js
@@ -37,6 +37,7 @@ var proto = {
 
   createdCallback: {
     value: function () {
+      this.isEntity = true;
       this.states = [];
       this.components = {};
       this.object3D = new THREE.Mesh();
@@ -51,8 +52,23 @@ var proto = {
 
   attachedCallback: {
     value: function () {
+      var self = this;
+      var children = this.getChildEntities();
+      var childrenLoaded = [];
+
+      children.forEach(function (child, i) {
+        childrenLoaded.push(new Promise(function (resolve) {
+          child.addEventListener('loaded', function () {
+            resolve();
+          });
+        }));
+      });
+
       this.addToParent();
-      this.load();
+
+      Promise.all(childrenLoaded).then(function () {
+        self.load();
+      });
     }
   },
 
@@ -77,6 +93,25 @@ var proto = {
         return;
       }
       this.updateComponent(attr, attrValue);
+    }
+  },
+
+  /**
+   * @returns {array} Direct children that are entities.
+   */
+  getChildEntities: {
+    value: function () {
+      var children = this.children;
+      var childEntities = [];
+
+      for (var i = 0; i < this.children.length; i++) {
+        var child = children[i];
+        if (child.isEntity) {
+          childEntities.push(child);
+        }
+      }
+
+      return childEntities;
     }
   },
 

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -53,19 +53,17 @@ module.exports = registerElement('a-node', {
         if (self.hasLoaded) { return; }
 
         // Default to waiting for all nodes.
-        if (!childFilter) {
-          childFilter = function (el) { return el.isNode; };
-        }
+        childFilter = childFilter || function (el) { return el.isNode; };
 
         // Wait for children to load (if any), then load.
         children = this.getChildren();
         childrenLoaded = children.filter(childFilter).map(function (child) {
-          return new Promise(function (resolve) {
+          return new Promise(function waitForLoaded (resolve) {
             child.addEventListener('loaded', resolve);
           });
         });
 
-        Promise.all(childrenLoaded).then(function () {
+        Promise.all(childrenLoaded).then(function emitLoaded () {
           if (cb) { cb(); }
           self.hasLoaded = true;
           self.emit('loaded', {}, false);

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -13,6 +13,7 @@ module.exports = registerElement('a-node', {
   prototype: Object.create(HTMLElement.prototype, {
     createdCallback: {
       value: function () {
+        this.hasLoaded = false;
         this.isNode = true;
         this.mixinEls = [];
         this.mixinObservers = {};
@@ -44,7 +45,7 @@ module.exports = registerElement('a-node', {
      * Then emit `loaded` event and set `hasLoaded`.
      */
     load: {
-      value: function (childFilter) {
+      value: function (cb, childFilter) {
         var children;
         var childrenLoaded;
         var self = this;
@@ -64,7 +65,9 @@ module.exports = registerElement('a-node', {
           });
         });
 
+
         Promise.all(childrenLoaded).then(function () {
+          if (cb) { cb(); }
           self.hasLoaded = true;
           self.emit('loaded', {}, false);
         });

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -4,6 +4,10 @@ var utils = require('../utils/');
 
 /**
  * Base class for A-Frame that manages loading of objects.
+ *
+ * Nodes can be modified using mixins.
+ * Nodes emit a `loaded` event when they and their children have initialized. Which children
+ * to wait for can be customized using `loadChildrenFilter`.
  */
 module.exports = registerElement('a-node', {
   prototype: Object.create(HTMLElement.prototype, {
@@ -18,14 +22,11 @@ module.exports = registerElement('a-node', {
     attachedCallback: {
       value: function () {
         var mixins = this.getAttribute('mixin');
+
         this.sceneEl = document.querySelector('a-scene');
         this.emit('nodeready', {}, false);
         if (mixins) { this.updateMixins(mixins); }
       }
-    },
-
-    detachedCallback: {
-      value: function () { /* no-op */ }
     },
 
     attributeChangedCallback: {
@@ -34,12 +35,49 @@ module.exports = registerElement('a-node', {
       }
     },
 
+    detachedCallback: {
+      value: function () { /* no-op */ }
+    },
+
+    /**
+     * Wait for children to load, if any.
+     * Then emit `loaded` event and set `hasLoaded`.
+     */
     load: {
+      value: function (childFilter) {
+        var children;
+        var childrenLoaded;
+        var self = this;
+
+        if (self.hasLoaded) { return; }
+
+        // Default to waiting for all nodes.
+        if (!childFilter) {
+          childFilter = function (el) { return el.isNode; };
+        }
+
+        // Wait for children to load (if any), then load.
+        children = this.getChildren();
+        childrenLoaded = children.filter(childFilter).map(function (child) {
+          return new Promise(function (resolve) {
+            child.addEventListener('loaded', resolve);
+          });
+        });
+
+        Promise.all(childrenLoaded).then(function () {
+          self.hasLoaded = true;
+          self.emit('loaded', {}, false);
+        });
+      }
+    },
+
+    getChildren: {
       value: function () {
-        // To prevent emmitting the loaded event more than once
-        if (this.hasLoaded) { return; }
-        this.hasLoaded = true;
-        this.emit('loaded', {}, false);
+        var children = [];
+        for (var i = 0; i < this.children.length; i++) {
+          children.push(this.children[i]);
+        }
+        return children;
       }
     },
 

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -65,7 +65,6 @@ module.exports = registerElement('a-node', {
           });
         });
 
-
         Promise.all(childrenLoaded).then(function () {
           if (cb) { cb(); }
           self.hasLoaded = true;

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -9,7 +9,6 @@ var Wakelock = require('../../lib/vendor/wakelock/wakelock');
 
 var dummyDolly = new THREE.Object3D();
 var controls = new THREE.VRControls(dummyDolly);
-var isNode = re.isNode;
 var DEFAULT_CAMERA_ATTR = 'data-aframe-default-camera';
 var DEFAULT_LIGHT_ATTR = 'data-aframe-default-light';
 var HIDDEN_CLASS = 'a-hidden';
@@ -30,8 +29,10 @@ var isMobile = utils.isMobile();
            updated on every tick.
  * @member {object} cameraEl - Set the entity with a camera component.
  * @member {object} canvas
+ * @member {bool} defaultCameraEnabled - false if user has not added camera.
  * @member {bool} defaultLightsEnabled - false if user has not added lights.
  * @member {Element} enterVREl
+ * @member {array} everythingLoaded - promises before kicking off.
  * @member {bool} insideIframe
  * @member {bool} insideLoader
  * @member {bool} isScene - Differentiates this as a scene entity as opposed
@@ -39,10 +40,8 @@ var isMobile = utils.isMobile();
  * @member {bool} isMobile - Whether browser is mobile (via UA detection).
  * @member {object} object3D - The root three.js Scene object.
  * @member {object} monoRenderer
- * @member {number} pendingElements - Number of elements currently waiting to
- *         initialize before beginning rendering.
  * @member {object} renderer
- * @member {bool} renderLoopStarted
+ * @member {bool} renderStarted
  * @member {object} stats
  * @member {object} stereoRenderer
  * @member {object} wakelock
@@ -52,8 +51,10 @@ var AScene = module.exports = registerElement('a-scene', {
     createdCallback: {
       value: function () {
         this.behaviors = [];
+        this.defaultCameraEnabled = true;
         this.defaultLightsEnabled = true;
         this.enterVREl = null;
+        this.everythingLoaded = [];
         this.insideIframe = window.top !== window.self;
         this.insideLoader = false;
         this.isScene = true;
@@ -78,10 +79,11 @@ var AScene = module.exports = registerElement('a-scene', {
         this.setupCanvas();
         this.setupKeyboardShortcuts();
         this.setupRenderer();
+        this.setupDefaultCamera();
         this.setupDefaultLights();
-        this.attachEventListeners();
         this.attachFullscreenListeners();
         this.attachOrientationListeners();
+        this.start();
 
         // For Chrome (https://github.com/aframevr/aframe-core/issues/321).
         window.addEventListener('load', resizeCanvas);
@@ -117,40 +119,6 @@ var AScene = module.exports = registerElement('a-scene', {
     addBehavior: {
       value: function (behavior) {
         this.behaviors.push(behavior);
-      }
-    },
-
-    /**
-     * Attaches event listeners to all assets and entities and wait for them
-     * all to load before kicking things off.
-     */
-    attachEventListeners: {
-      value: function () {
-        var self = this;
-        var elementLoadedCallback = this.elementLoadedCallback.bind(this);
-        this.pendingElements = 0;
-        var assets = document.querySelector('a-assets');
-        if (assets && !assets.hasLoaded) {
-          this.pendingElements++;
-          attachEventListener(assets);
-        }
-
-        var children = this.querySelectorAll('*');
-        Array.prototype.slice.call(children).forEach(countElement);
-
-        function countElement (node) {
-          if (!isNode(node)) { return; }
-          self.pendingElements++;
-          if (!node.hasLoaded) {
-            attachEventListener(node);
-          } else {
-            elementLoadedCallback(node);
-          }
-        }
-
-        function attachEventListener (node) {
-          node.addEventListener('loaded', elementLoadedCallback);
-        }
       }
     },
 
@@ -232,34 +200,6 @@ var AScene = module.exports = registerElement('a-scene', {
     },
 
     /**
-     * Handler attached to elements to help scene know when to kick off.
-     * Scene waits for all entities to load.
-     */
-    elementLoadedCallback: {
-      value: function () {
-        this.pendingElements--;
-        // Still waiting on elements.
-        if (this.pendingElements > 0) { return; }
-        // Render loop already running.
-        if (this.renderLoopStarted) { return; }
-
-        this.setupLoader();
-        if (!this.cameraEl) {
-          // Add default camera if user has not added one. Wait for it to load.
-          this.setupDefaultCamera();
-          return;
-        }
-        this.resizeCanvas();
-
-        // Kick off render loop.
-        this.render();
-        this.renderLoopStarted = true;
-        this.load();
-        this.checkUrlParameters();
-      }
-    },
-
-    /**
      * Enters VR when ?mode=vr is specified in the querystring.
      */
     checkUrlParameters: {
@@ -322,28 +262,49 @@ var AScene = module.exports = registerElement('a-scene', {
       }
     },
 
+    /**
+     * Trigger ANode `loaded`.
+     */
     load: {
       value: function () {
-        // To prevent emmitting the loaded event more than once
-        // and to prevent triggering loaded if there are still
-        // pending elements to be loaded
-        if (this.hasLoaded || this.pendingElements !== 0) { return; }
-        AEntity.prototype.load.call(this);
+        if (this.hasLoaded) { return; }
+        AEntity.prototype.load.call(this, function (el) {
+          return el.isNode;
+        });
       }
     },
 
     /**
-     * Notify scene that light has been added and to remove the default
+     * Notify scene that camera has been added and to remove the default.
+     *
+e    * @param {object} el - element holding the camera component.
+     */
+    registerCamera: {
+      value: function (el) {
+        var defaultCamera;
+        if (this.defaultCameraEnabled && !el.parentNode.hasAttribute(DEFAULT_CAMERA_ATTR)) {
+          // User added a camera, remove default camera through DOM.
+          defaultCamera = document.querySelector('[' + DEFAULT_CAMERA_ATTR + ']');
+          if (defaultCamera) {
+            this.removeChild(defaultCamera);
+          }
+          this.cameraEl = el;
+          this.defaultCameraEnabled = false;
+        }
+      }
+    },
+
+    /**
+     * Notify scene that light has been added and to remove the default.
      *
      * @param {object} el - element holding the light component.
      */
     registerLight: {
       value: function (el) {
-        if (this.defaultLightsEnabled &&
-            !el.hasAttribute(DEFAULT_LIGHT_ATTR)) {
+        var defaultLights;
+        if (this.defaultLightsEnabled && !el.hasAttribute(DEFAULT_LIGHT_ATTR)) {
           // User added a light, remove default lights through DOM.
-          var defaultLights = document.querySelectorAll(
-            '[' + DEFAULT_LIGHT_ATTR + ']');
+          defaultLights = document.querySelectorAll('[' + DEFAULT_LIGHT_ATTR + ']');
           for (var i = 0; i < defaultLights.length; i++) {
             this.removeChild(defaultLights[i]);
           }
@@ -479,9 +440,7 @@ var AScene = module.exports = registerElement('a-scene', {
         defaultCamera.setAttribute('camera');
         defaultCamera.setAttribute('wasd-controls');
         defaultCamera.setAttribute('look-controls');
-        this.pendingElements++;
-        defaultCamera.addEventListener('loaded',
-                                       this.elementLoadedCallback.bind(this));
+        this.cameraEl = defaultCamera;
         cameraWrapperEl.appendChild(defaultCamera);
         this.appendChild(cameraWrapperEl);
       }
@@ -632,6 +591,32 @@ var AScene = module.exports = registerElement('a-scene', {
         if (this.enterVREl) {
           this.enterVREl.classList.remove(HIDDEN_CLASS);
         }
+      }
+    },
+
+    /**
+     * Handler attached to elements to help scene know when to kick off.
+     * Scene waits for all entities to load.
+     */
+    start: {
+      value: function () {
+        if (this.renderStarted) { return; }
+
+        this.addEventListener('loaded', function () {
+          if (this.renderStarted) { return; }
+
+          this.setupLoader();
+          this.resizeCanvas();
+
+          // Kick off render loop.
+          this.render();
+          this.renderStarted = true;
+          this.emit('renderstart');
+
+          this.checkUrlParameters();
+        });
+
+        this.load();
       }
     },
 

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -32,7 +32,6 @@ var isMobile = utils.isMobile();
  * @member {bool} defaultCameraEnabled - false if user has not added camera.
  * @member {bool} defaultLightsEnabled - false if user has not added lights.
  * @member {Element} enterVREl
- * @member {array} everythingLoaded - promises before kicking off.
  * @member {bool} insideIframe
  * @member {bool} insideLoader
  * @member {bool} isScene - Differentiates this as a scene entity as opposed
@@ -54,7 +53,6 @@ var AScene = module.exports = registerElement('a-scene', {
         this.defaultCameraEnabled = true;
         this.defaultLightsEnabled = true;
         this.enterVREl = null;
-        this.everythingLoaded = [];
         this.insideIframe = window.top !== window.self;
         this.insideLoader = false;
         this.isScene = true;
@@ -259,18 +257,6 @@ var AScene = module.exports = registerElement('a-scene', {
         if (this.enterVREl) {
           this.enterVREl.classList.add(HIDDEN_CLASS);
         }
-      }
-    },
-
-    /**
-     * Trigger ANode `loaded`.
-     */
-    load: {
-      value: function () {
-        if (this.hasLoaded) { return; }
-        AEntity.prototype.load.call(this, function (el) {
-          return el.isNode;
-        });
       }
     },
 
@@ -616,7 +602,7 @@ e    * @param {object} el - element holding the camera component.
           this.checkUrlParameters();
         });
 
-        this.load();
+        AEntity.prototype.load.call(this);
       }
     },
 

--- a/tests/components/fog.test.js
+++ b/tests/components/fog.test.js
@@ -6,15 +6,11 @@ suite('fog', function () {
   'use strict';
 
   setup(function () {
-    var el;
     this.entityEl = entityFactory();
-    el = this.el = this.entityEl.parentNode;
+    var el = this.el = this.entityEl.parentNode;
     this.updateMaterialsSpy = this.sinon.spy(AScene.prototype, 'updateMaterials');
 
-    // We force loading of the scene since the logic
-    // that fires the event is in attachedCallback
-    // which is stubbed to avoid running any WebGL code
-    el.pendingElements = 0;
+    // Stub scene load to avoid WebGL code.
     el.load();
     el.setAttribute('fog', '');
   });

--- a/tests/components/look-at.test.js
+++ b/tests/components/look-at.test.js
@@ -67,14 +67,12 @@ suite('look-at', function () {
       nestedEl.setAttribute('position', '1 2 3');
       nestedEl.setAttribute('id', 'squirrel-nest');
       anotherEl.appendChild(nestedEl);
-      nestedEl.addEventListener('loaded', function () {
+      nestedEl.parentNode.addEventListener('loaded', function () {
         el.setAttribute('look-at', '#squirrel-nest');
         el.parentNode.object3D.updateMatrixWorld();
-        setTimeout(function () {
-          el.components['look-at'].update();
-          assert.ok(spy.calledWith({x: 2, y: 4, z: 6}));
-          done();
-        });
+        el.components['look-at'].update();
+        assert.ok(spy.calledWith({x: 2, y: 4, z: 6}));
+        done();
       });
     });
 

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -58,7 +58,7 @@ suite('a-animation', function () {
   });
 
   suite('update', function () {
-    test('it is called on initialization', function (done) {
+    test('called on initialization', function (done) {
       this.sinon.stub(AAnimation.prototype, 'update');
       setupAnimation({}, function (el, animationEl) {
         sinon.assert.called(AAnimation.prototype.update);

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -44,6 +44,21 @@ suite('a-entity', function () {
         done();
       });
     });
+
+    test('waits for children to load', function (done) {
+      var entity = document.createElement('a-entity');
+      var entityChild1 = document.createElement('a-entity');
+      var entityChild2 = document.createElement('a-entity');
+      entity.appendChild(entityChild1);
+      entity.appendChild(entityChild2);
+      document.body.appendChild(entity);
+
+      entity.addEventListener('loaded', function () {
+        assert.ok(entityChild1.hasLoaded);
+        assert.ok(entityChild2.hasLoaded);
+        done();
+      });
+    });
   });
 
   /**
@@ -147,6 +162,26 @@ suite('a-entity', function () {
       var el = this.el;
       el.setAttribute('class', 'pied piper');
       assert.equal(el.getAttribute('class'), 'pied piper');
+    });
+  });
+
+  suite('getChildEntities', function () {
+    test('returns child entities', function (done) {
+      var entity = document.createElement('a-entity');
+      var animationChild = document.createElement('a-animation');
+      var entityChild1 = document.createElement('a-entity');
+      var entityChild2 = document.createElement('a-entity');
+      entity.appendChild(animationChild);
+      entity.appendChild(entityChild1);
+      entity.appendChild(entityChild2);
+      document.body.appendChild(entity);
+
+      entity.addEventListener('loaded', function () {
+        var childEntities = entity.getChildEntities();
+        assert.equal(childEntities.length, 2);
+        assert.equal(childEntities.indexOf(animationChild), -1);
+        done();
+      });
     });
   });
 

--- a/tests/core/a-node.test.js
+++ b/tests/core/a-node.test.js
@@ -1,0 +1,118 @@
+/* global assert, setup, suite, test */
+
+suite('a-node', function () {
+  'use strict';
+
+  setup(function () {
+    this.el = document.createElement('a-node');
+  });
+
+  suite('emit', function () {
+    test('can emit event', function (done) {
+      var el = this.el;
+      el.addEventListener('hadouken', function () {
+        done();
+      });
+      el.emit('hadouken');
+    });
+
+    test('can emit event with detail', function (done) {
+      var el = this.el;
+      el.addEventListener('hadouken', function (event) {
+        assert.equal(event.detail.power, 10);
+        assert.equal(event.detail.target, el);
+        done();
+      });
+      el.emit('hadouken', { power: 10 });
+    });
+
+    test('bubbles', function (done) {
+      var el = this.el;
+      var child = document.createElement('a-node');
+      el.appendChild(child);
+      el.addEventListener('hadouken', function (event) {
+        done();
+      });
+      child.emit('hadouken', {}, true);
+    });
+
+    test('can disable bubble', function (done) {
+      var el = this.el;
+      var child = document.createElement('a-node');
+      el.appendChild(child);
+      el.addEventListener('hadouken', function (event) {
+        // Failure case.
+        assert.equal(1, 2);
+        done();
+      });
+      child.emit('hadouken', {}, false);
+      setTimeout(function () {
+        done();
+      }, 50);
+    });
+  });
+
+  suite('getChildren', function () {
+    test('returns all children', function () {
+      var el = this.el;
+      var child1 = document.createElement('a-node');
+      var child2 = document.createElement('a');
+      var child3 = document.createElement('a-entity');
+      var nestedChild = document.createElement('a-node');
+      child1.appendChild(nestedChild);
+      el.appendChild(child1);
+      el.appendChild(child2);
+      el.appendChild(child3);
+      assert.deepEqual(el.getChildren(), [
+        child1, child2, child3
+      ]);
+    });
+  });
+
+  suite('load', function () {
+    test('can load when empty', function (done) {
+      var el = this.el;
+      el.load();
+      el.addEventListener('loaded', function () {
+        done();
+      });
+    });
+
+    test('sets hasLoaded', function (done) {
+      var el = this.el;
+      assert.notOk(el.hasLoaded);
+      el.load();
+      el.addEventListener('loaded', function () {
+        assert.ok(el.hasLoaded);
+        done();
+      });
+    });
+
+    test('can load with a child node', function (done) {
+      var el = this.el;
+      var child = document.createElement('a-node');
+      el.appendChild(child);
+      child.load();
+      el.load();
+      el.addEventListener('loaded', function () {
+        done();
+      });
+    });
+
+    test('can load with a callback', function (done) {
+      this.el.load(function () {
+        done();
+      });
+    });
+
+    test('does not wait for non-nodes to load', function (done) {
+      var el = this.el;
+      var a = document.createElement('a');
+      el.appendChild(a);
+      el.load();
+      el.addEventListener('loaded', function () {
+        done();
+      });
+    });
+  });
+});

--- a/tests/core/a-scene.test.js
+++ b/tests/core/a-scene.test.js
@@ -98,7 +98,7 @@ helpers.getSkipCISuite()('a-scene (with renderer)', function () {
     process.nextTick(function () {
       el = self.el = document.createElement('a-scene');
       document.body.appendChild(el);
-      el.addEventListener('loaded', function () {
+      el.addEventListener('renderstart', function () {
         done();
       });
     });
@@ -125,10 +125,19 @@ helpers.getSkipCISuite()('a-scene (with renderer)', function () {
       var cancelSpy = this.sinon.spy(window, 'cancelAnimationFrame');
 
       assert.ok(el.animationFrameID);
-      el.parentNode.removeChild(el);
+      document.body.removeChild(el);
       process.nextTick(function () {
         assert.notOk(el.animationFrameID);
         assert.ok(cancelSpy.calledWith(animationFrameID));
+        done();
+      });
+    });
+
+    test('does not destroy document.body', function (done) {
+      var el = this.el;
+      document.body.removeChild(el);
+      process.nextTick(function () {
+        assert.ok(document.body);
         done();
       });
     });

--- a/tests/core/component.test.js
+++ b/tests/core/component.test.js
@@ -35,12 +35,14 @@ suite('component', function () {
 
     test('can change behavior of entity', function (done) {
       var el = entityFactory();
+      registerComponent('clone', cloneComponent);
+
       el.addEventListener('loaded', function () {
         assert.notOk('clone' in el.components);
         assert.notOk(el.object3D.children.length);
         el.setAttribute('clone', '');
         assert.ok('clone' in el.components);
-        assert.ok(el.object3D.children[0].uuid, 'Bubble Fett');
+        assert.equal(el.object3D.children[0].uuid, 'Bubble Fett');
         done();
       });
     });


### PR DESCRIPTION
- unblocks components that change the behavior of its children entities (e.g., layout component)
- creates `getChildEntities` method that returns Array over NodeList
- three tests initially failed (look at, animation), had to make some tweaks to get it working

**Loading logic**
- consolidates loading logic into ANode. AEntity/AScene/AAssets can customize what kind of children they wait upon before loading using a function.
- use promises
- scene loading logic changes. rather than keeping track of elements as they are added and decrementing count as they are loaded, it utilizes ANode's loading logic which waits for all of its direct children nodes to load before loading. And all of those children nodes are waiting for _its_ children nodes before loading. So recursion satisfies waiting for all nodes in scene to load.
- scene default camera logic made to match default light logic to ease loading logic
- scene now fires `loaded` when its children loads, which is used to determine when to render. another event is added `renderstart` for those that want to listen to it.
