### PR TITLE
browserify-css should be a direct dependency, not devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "main": "src/index.js",
   "dependencies": {
+    "browserify-css": "^0.8.2",
     "debug": "^2.2.0",
     "document-register-element": "^0.5.2",
     "es6-promise": "^3.0.2",
@@ -18,7 +19,6 @@
   },
   "devDependencies": {
     "browserify": "^11.0.1",
-    "browserify-css": "^0.8.2",
     "budo": "^7.0.2",
     "chai-shallow-deep-equal": "^1.3.0",
     "exorcist": "^0.4.0",


### PR DESCRIPTION
When using the `package.json` "browserify" field, those transforms should be listed as direct dependencies. Otherwise users will have to manually install the transform (like in [this component](https://github.com/ngokevin/aframe-text-component/blob/2466957b7c512417609695ab22e94a10386cfe92/package.json#L39)), and they may end up getting the wrong version of the transform.
