### PR TITLE
The editor needs to be able to stop all dynamic behavior of a scene s…

### DIFF
--- a/src/components/camera.js
+++ b/src/components/camera.js
@@ -3,6 +3,7 @@ var THREE = require('../../lib/three');
 
 module.exports.Component = registerComponent('camera', {
   schema: {
+    active: { default: true },
     far: { default: 10000 },
     fov: { default: 80, min: 0 },
     near: { default: 0.5, min: 0 }
@@ -17,13 +18,14 @@ module.exports.Component = registerComponent('camera', {
     var el = this.el;
     camera.el = el;
     el.object3D.add(camera);
-    el.sceneEl.setActiveCamera(camera);
   },
 
   /**
    * Updates three.js camera.
    */
-  update: function () {
+  update: function (oldData) {
+    var el = this.el;
+    var sceneEl = el.sceneEl;
     var data = this.data;
     var camera = this.camera;
     camera.aspect = data.aspect || (window.innerWidth / window.innerHeight);
@@ -31,5 +33,14 @@ module.exports.Component = registerComponent('camera', {
     camera.fov = data.fov;
     camera.near = data.near;
     camera.updateProjectionMatrix();
+    // If the active property has changes or on first update call
+    if (!oldData || oldData.active !== data.active) {
+      if (data.active) {
+        sceneEl.setActiveCamera(camera);
+      } else if (sceneEl.camera === camera) {
+        // If the camera is disabled and is the current active one
+        sceneEl.setActiveCamera();
+      }
+    }
   }
 });

--- a/src/components/look-controls.js
+++ b/src/components/look-controls.js
@@ -12,17 +12,40 @@ module.exports.Component = registerComponent('look-controls', {
   },
 
   init: function () {
-    var scene = this.el.sceneEl;
-    this.setupMouseControls();
-    this.setupHMDControls();
-    this.attachEventListeners();
-    scene.addBehavior(this);
     this.previousPosition = new THREE.Vector3();
     this.deltaPosition = new THREE.Vector3();
+    this.setupMouseControls();
+    this.setupHMDControls();
+    this.bindMethods();
+  },
+
+  bindMethods: function () {
+    this.onMouseDown = this.onMouseDown.bind(this);
+    this.onMouseMove = this.onMouseMove.bind(this);
+    this.releaseMouse = this.releaseMouse.bind(this);
+    this.onTouchStart = this.onTouchStart.bind(this);
+    this.onTouchMove = this.onTouchMove.bind(this);
+    this.onTouchEnd = this.onTouchEnd.bind(this);
+  },
+
+  play: function () {
+    var scene = this.el.sceneEl;
+    this.previousPosition.set(0, 0, 0);
+    this.addEventListeners();
+    scene.addBehavior(this);
+  },
+
+  pause: function () {
+    var scene = this.el.sceneEl;
+    this.removeEventListeners();
+    scene.removeBehavior(this);
+  },
+
+  remove: function () {
+    this.pause();
   },
 
   setupMouseControls: function () {
-    this.canvasEl = document.querySelector('a-scene').canvas;
     // The canvas where the scene is painted
     this.mouseDown = false;
     this.pitchObject = new THREE.Object3D();
@@ -38,19 +61,36 @@ module.exports.Component = registerComponent('look-controls', {
     this.zeroQuaternion = new THREE.Quaternion();
   },
 
-  attachEventListeners: function () {
+  addEventListeners: function () {
     var canvasEl = document.querySelector('a-scene').canvas;
 
     // Mouse Events
-    canvasEl.addEventListener('mousedown', this.onMouseDown.bind(this), true);
-    canvasEl.addEventListener('mousemove', this.onMouseMove.bind(this), true);
-    canvasEl.addEventListener('mouseup', this.releaseMouse.bind(this), true);
-    canvasEl.addEventListener('mouseout', this.releaseMouse.bind(this), true);
+    canvasEl.addEventListener('mousedown', this.onMouseDown, false);
+    canvasEl.addEventListener('mousemove', this.onMouseMove, false);
+    canvasEl.addEventListener('mouseup', this.releaseMouse, false);
+    canvasEl.addEventListener('mouseout', this.releaseMouse, false);
 
     // Touch events
-    canvasEl.addEventListener('touchstart', this.onTouchStart.bind(this));
-    canvasEl.addEventListener('touchmove', this.onTouchMove.bind(this));
-    canvasEl.addEventListener('touchend', this.onTouchEnd.bind(this));
+    canvasEl.addEventListener('touchstart', this.onTouchStart);
+    canvasEl.addEventListener('touchmove', this.onTouchMove);
+    canvasEl.addEventListener('touchend', this.onTouchEnd);
+  },
+
+  removeEventListeners: function () {
+    var sceneEl = document.querySelector('a-scene');
+    var canvasEl = sceneEl && sceneEl.canvas;
+    if (!canvasEl) { return; }
+
+    // Mouse Events
+    canvasEl.removeEventListener('mousedown', this.onMouseDown);
+    canvasEl.removeEventListener('mousemove', this.onMouseMove);
+    canvasEl.removeEventListener('mouseup', this.releaseMouse);
+    canvasEl.removeEventListener('mouseout', this.releaseMouse);
+
+    // Touch events
+    canvasEl.removeEventListener('touchstart', this.onTouchStart);
+    canvasEl.removeEventListener('touchmove', this.onTouchMove);
+    canvasEl.removeEventListener('touchend', this.onTouchEnd);
   },
 
   update: function () {

--- a/src/components/raycaster.js
+++ b/src/components/raycaster.js
@@ -6,11 +6,20 @@ module.exports.Component = registerComponent('raycaster', {
   init: function () {
     this.raycaster = new THREE.Raycaster();
     this.intersectedEl = null;
+  },
+
+  play: function () {
     this.pollForHoverIntersections();
   },
 
-  remove: function () {
+  pause: function () {
+    var pollInterval = this.pollInterval;
+    if (!pollInterval) { return; }
     requestInterval.clear(this.pollInterval);
+  },
+
+  remove: function () {
+    this.pause();
   },
 
   pollForHoverIntersections: function () {

--- a/src/components/wasd-controls.js
+++ b/src/components/wasd-controls.js
@@ -37,17 +37,27 @@ module.exports.Component = registerComponent('wasd-controls', {
   },
 
   init: function () {
-    this.setupControls();
-  },
-
-  setupControls: function () {
-    var scene = this.el.sceneEl;
-    this.prevTime = Date.now();
+    this.velocity = new THREE.Vector3();
     // To keep track of the pressed keys
     this.keys = {};
-    this.velocity = new THREE.Vector3();
+    this.onKeyDown = this.onKeyDown.bind(this);
+    this.onKeyUp = this.onKeyUp.bind(this);
+  },
+
+  play: function () {
+    var scene = this.el.sceneEl;
     this.attachEventListeners();
     scene.addBehavior(this);
+  },
+
+  pause: function () {
+    var scene = this.el.sceneEl;
+    this.removeEventListeners();
+    scene.removeBehavior(this);
+  },
+
+  remove: function () {
+    this.pause();
   },
 
   update: function (previousData) {
@@ -55,8 +65,9 @@ module.exports.Component = registerComponent('wasd-controls', {
     var acceleration = data.acceleration;
     var easing = data.easing;
     var velocity = this.velocity;
+    var prevTime = this.prevTime = this.prevTime || Date.now();
     var time = window.performance.now();
-    var delta = (time - this.prevTime) / 1000;
+    var delta = (time - prevTime) / 1000;
     var keys = this.keys;
     var movementVector;
     var adAxis = data.adAxis;
@@ -104,8 +115,14 @@ module.exports.Component = registerComponent('wasd-controls', {
 
   attachEventListeners: function () {
     // Keyboard events
-    window.addEventListener('keydown', this.onKeyDown.bind(this), false);
-    window.addEventListener('keyup', this.onKeyUp.bind(this), false);
+    window.addEventListener('keydown', this.onKeyDown, false);
+    window.addEventListener('keyup', this.onKeyUp, false);
+  },
+
+  removeEventListeners: function () {
+    // Keyboard events
+    window.removeEventListener('keydown', this.onKeyDown);
+    window.removeEventListener('keyup', this.onKeyUp);
   },
 
   onKeyDown: function (event) {

--- a/src/core/a-animation.js
+++ b/src/core/a-animation.js
@@ -60,6 +60,7 @@ module.exports.AAnimation = registerElement('a-animation', {
   prototype: Object.create(ANode.prototype, {
     createdCallback: {
       value: function () {
+        this.bindMethods();
         this.isRunning = false;
         this.partialSetAttribute = function () { /* no-op */ };
         this.tween = null;
@@ -83,7 +84,6 @@ module.exports.AAnimation = registerElement('a-animation', {
         }
 
         function init () {
-          self.bindMethods();
           self.applyMixin();
           self.update();
           self.load();
@@ -221,7 +221,7 @@ module.exports.AAnimation = registerElement('a-animation', {
 
     start: {
       value: function () {
-        if (this.isRunning) { return; }
+        if (this.isRunning || this.el.paused) { return; }
         this.tween = this.getTween();
         this.isRunning = true;
         this.tween.start();
@@ -237,6 +237,7 @@ module.exports.AAnimation = registerElement('a-animation', {
         tween.stop();
         this.isRunning = false;
         this.partialSetAttribute(this.initialValue);
+        this.emit('animationstop');
       },
       writable: true
     },
@@ -280,10 +281,12 @@ module.exports.AAnimation = registerElement('a-animation', {
     addEventListeners: {
       value: function (evts) {
         var el = this.el;
-        var start = this.start.bind(this);
+        var self = this;
         utils.splitString(evts).forEach(function (evt) {
-          el.addEventListener(evt, start);
+          el.addEventListener(evt, self.start);
         });
+        el.addEventListener('play', this.start);
+        el.addEventListener('pause', this.stop);
         el.addEventListener('stateadded', this.onStateAdded);
         el.addEventListener('stateremoved', this.onStateRemoved);
       }

--- a/src/core/a-node.js
+++ b/src/core/a-node.js
@@ -24,7 +24,7 @@ module.exports = registerElement('a-node', {
       value: function () {
         var mixins = this.getAttribute('mixin');
 
-        this.sceneEl = document.querySelector('a-scene');
+        this.sceneEl = this.closest('a-scene');
         this.emit('nodeready', {}, false);
         if (mixins) { this.updateMixins(mixins); }
       }
@@ -33,6 +33,25 @@ module.exports = registerElement('a-node', {
     attributeChangedCallback: {
       value: function (attr, oldVal, newVal) {
         if (attr === 'mixin') { this.updateMixins(newVal, oldVal); }
+      }
+    },
+
+    /**
+     * returns the first element that matches a CSS
+     * selector by traversing up the DOM tree starting
+     * from (and including) the receiver element.
+     * @param {string} selector - CSS selector of the matcched element
+     */
+    closest: {
+      value: function closest (selector) {
+        var matches = this.matches || this.mozMatchesSelector ||
+          this.msMatchesSelector || this.oMatchesSelector || this.webkitMatchesSelector;
+        var element = this;
+        while (element) {
+          if (matches.call(element, selector)) { break; }
+          element = element.parentElement;
+        }
+        return element;
       }
     },
 
@@ -68,7 +87,8 @@ module.exports = registerElement('a-node', {
           self.hasLoaded = true;
           self.emit('loaded', {}, false);
         });
-      }
+      },
+      writable: true
     },
 
     getChildren: {

--- a/src/core/component.js
+++ b/src/core/component.js
@@ -52,6 +52,18 @@ Component.prototype = {
   init: function () { /* no-op */ },
 
   /**
+   * Called to start any dynamic behavior
+   * like animations, AI, physics.
+   */
+  play: function () { /* no-op */ },
+
+  /**
+   * Called to stop any dynamic behavior
+   * like animations, AI, physics.
+   */
+  pause: function () { /* no-op */ },
+
+  /**
    * Update handler. Similar to attributeChangedCallback.
    * Called whenever component's data changes.
    * Also called on component initialization when the component receives initial data.
@@ -182,7 +194,7 @@ module.exports.registerComponent = function (name, definition) {
   Object.keys(definition).forEach(function (key) {
     proto[key] = {
       value: definition[key],
-      writable: window.debug
+      writable: true
     };
   });
 

--- a/tests/__init.test.js
+++ b/tests/__init.test.js
@@ -9,8 +9,10 @@ var AScene = require('core/a-scene');
 
 setup(function () {
   this.sinon = sinon.sandbox.create();
-  // Stub to not create a WebGL context since Travis CI runs headless.
-  this.sinon.stub(AScene.prototype, 'attachedCallback');
+  // Stubs to not create a WebGL context since Travis CI runs headless.
+  this.sinon.stub(AScene.prototype, 'setupRenderer');
+  this.sinon.stub(AScene.prototype, 'resizeCanvas');
+  this.sinon.stub(AScene.prototype, 'render');
 });
 
 teardown(function () {

--- a/tests/components/camera.test.js
+++ b/tests/components/camera.test.js
@@ -5,15 +5,9 @@ suite('camera', function () {
   'use strict';
 
   setup(function (done) {
-    var self = this;
     var el = this.el = entityFactory();
     el.setAttribute('camera', '');
-    if (el.hasLoaded) {
-      this.camera = el.components.camera.camera;
-      done();
-    }
-    el.addEventListener('loaded', function () {
-      self.camera = el.components.camera.camera;
+    process.nextTick(function () {
       done();
     });
   });
@@ -24,7 +18,9 @@ suite('camera', function () {
     });
 
     test('sets sceneEl.camera', function () {
-      assert.equal(this.el.sceneEl.camera, this.camera);
+      var el = this.el;
+      el.setAttribute('camera', 'active: true');
+      assert.equal(el.sceneEl.camera, el.components.camera.camera);
     });
   });
 

--- a/tests/core/a-animation.test.js
+++ b/tests/core/a-animation.test.js
@@ -35,6 +35,7 @@ function setupAnimation (animationAttrs, cb, elAttrs) {
   animationEl.addEventListener('loaded', function () {
     animationEl.start();
   });
+  el.paused = false;
   el.appendChild(animationEl);
 }
 
@@ -283,6 +284,7 @@ suite('a-animation', function () {
       var animationEl = document.createElement('a-animation');
       animationEl.setAttribute('begin', 'click');
       var el = helpers.entityFactory();
+      el.paused = false;
       el.appendChild(animationEl);
       animationEl.addEventListener('loaded', function () {
         el.emit('click');

--- a/tests/core/a-entity.test.js
+++ b/tests/core/a-entity.test.js
@@ -127,7 +127,7 @@ suite('a-entity', function () {
       var parentEl = el.parentNode;
       parentEl.removeChild(el);
       process.nextTick(function () {
-        assert.equal(parentEl.object3D.children.length, 0);
+        assert.equal(parentEl.object3D.children.length, 3);
         done();
       });
     });


### PR DESCRIPTION
…o the original DOM remains untouched and ready for edition. This patch

implements a mechanism to reset the scene to the original HTML and stop the dynamic behavior of animations and components. We need to extend the
component API with two new functions to start/stop eventListeners/animations or any other behavior that might modify the DOM based on time, events
or user input. The scene public API of the scene is:
- sceneEl.reset() to reset the initial state of the scene.
- sceneEl.reset(true) to reset the scene and pause dynamic behavior.
