### PR TITLE
swap out snazzy for standard-reporter (fixes #756)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "mozilla-download": "^1.0.5",
     "replace": "^0.3.0",
     "semistandard": "^7.0.2",
-    "snazzy": "^2.0.1",
+    "standard-reporter": "^1.0.5",
     "uglifyjs": "^2.4.10"
   },
   "scripts": {
@@ -53,7 +53,7 @@
     "release:push": "npm login && npm publish && git push --follow-tags",
     "test": "karma start ./tests/karma.conf.js",
     "test:ci": "TEST_ENV=ci karma start ./tests/karma.conf.js --single-run",
-    "lint": "semistandard -v $(git ls-files '*.js') | snazzy",
+    "lint": "semistandard -v $(git ls-files '*.js') | standard-reporter --stylish",
     "precommit": "npm run lint"
   },
   "repository": "aframevr/aframe-core",

--- a/scripts/budo.js
+++ b/scripts/budo.js
@@ -47,7 +47,7 @@ var app = budo(consts.ENTRY + ':' + consts.BUILD, opts);
 
 app.watch(consts.WATCH)
 .on('update', function () {
-  execCmd('semistandard -v $(git ls-files "*.js") | snazzy');
+  execCmd('semistandard -v $(git ls-files "*.js") | standard-reporter --stylish');
 });
 
 if (opts.live) {

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -269,8 +269,8 @@ var AScene = module.exports = registerElement('a-scene', {
         var defaultCamera;
         var defaultCameraEl;
         // el is an entity with a camera component
-        if (el.components && el.components.camera) { 
-          camera = el.components.camera.camera; 
+        if (el.components && el.components.camera) {
+          camera = el.components.camera.camera;
           cameraEl = el;
         } else if (el instanceof THREE.Camera) {
           camera = el;
@@ -604,14 +604,14 @@ var AScene = module.exports = registerElement('a-scene', {
           this.setupLoader();
           this.resizeCanvas();
 
-          if (!this.camera) { 
+          if (!this.camera) {
             this.setupDefaultCamera(startRender);
             return;
           }
 
           startRender();
 
-          function startRender() {
+          function startRender () {
             // Kick off render loop.
             self.render();
             self.renderStarted = true;

--- a/tests/components/camera.test.js
+++ b/tests/components/camera.test.js
@@ -9,8 +9,8 @@ suite('camera', function () {
     var el = this.el = entityFactory();
     el.setAttribute('camera', '');
     if (el.hasLoaded) {
-      this.camera = el.components.camera.camera; 
-      done(); 
+      this.camera = el.components.camera.camera;
+      done();
     }
     el.addEventListener('loaded', function () {
       self.camera = el.components.camera.camera;

--- a/tests/core/a-scene.test.js
+++ b/tests/core/a-scene.test.js
@@ -1,4 +1,4 @@
-/* global assert, process, setup, suite, test */
+/* global assert, process, setup, suite, test, THREE */
 'use strict';
 var helpers = require('../helpers');
 var AScene = require('core/a-scene');
@@ -59,11 +59,11 @@ suite('a-scene (without renderer)', function () {
       var cameraEl = document.createElement('a-entity');
       cameraEl.setAttribute('camera', '');
       this.el.appendChild(cameraEl);
-      cameraEl.addEventListener('loaded', function() {
+      cameraEl.addEventListener('loaded', function () {
         self.el.setActiveCamera(cameraEl);
         assert.equal(self.el.camera, cameraEl.components.camera.camera);
         done();
-      })
+      });
     });
   });
 


### PR DESCRIPTION
In issue #756 it was reported that [`snazzy`](https://www.npmjs.com/package/snazzy) has too many dependencies and nested dependencies which are causing lots of subdirectories to be created in its `node_modules` directory.

I found a similar library with a much smaller footprint, [`standard-reporter`](https://www.npmjs.com/package/standard-reporter).

And its output is prettier:

<img width="605" alt="screenshot 2015-12-28 14 24 48" src="https://cloud.githubusercontent.com/assets/203725/12024166/4d1fc5e2-ad6f-11e5-82d9-7e56b993d6ee.png">
