### PR TITLE
Setting to render canvas inside a-scene element instead in body

### DIFF
--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -402,13 +402,21 @@ var AScene = module.exports = registerElement('a-scene', {
 
     setupCanvas: {
       value: function () {
+        var appendToScene = this.getAttribute('append-canvas') === 'true';
+
         var canvas = this.canvas = document.createElement('canvas');
         canvas.classList.add('a-canvas');
         // Prevents overscroll on mobile devices.
         canvas.addEventListener('touchmove', function (evt) {
           evt.preventDefault();
         });
-        document.body.appendChild(canvas);
+
+        if (appendToScene) {
+          this.appendChild(canvas);
+        } else {
+          document.body.appendChild(canvas);
+        }
+
         window.addEventListener('resize', this.resizeCanvas.bind(this), false);
       }
     },


### PR DESCRIPTION
`<a-scene append-canvas="true">` will make the canvas be rendered inside the `<a-scene>` rather than directly in the body. The latter is not compatible with React use cases where `<a-scene>` is removed and added multiple times.

Personally, I don't understand why rendering the canvas inside the `<a-scene>` element is not just the default and only way, but making that change now is likely to be breaking. 

This PR is related to https://github.com/aframevr/aframe-core/issues/625, but I prefer to simply render the canvas inside `<a-scene>` instead of specifying a selector to an existing canvas or parent element.
