### PR TITLE
[BREAKING] Canvas element created inside a-scene element, configurable canvas

### DIFF
--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -402,13 +402,22 @@ var AScene = module.exports = registerElement('a-scene', {
 
     setupCanvas: {
       value: function () {
-        var canvas = this.canvas = document.createElement('canvas');
+        var canvasSelector = this.getAttribute('canvas');
+        var canvas;
+
+        if (canvasSelector) {
+          canvas = this.canvas = document.querySelector(canvasSelector);
+        } else {
+          canvas = this.canvas = document.createElement('canvas');
+          this.appendChild(canvas);
+        }
+
         canvas.classList.add('a-canvas');
         // Prevents overscroll on mobile devices.
         canvas.addEventListener('touchmove', function (evt) {
           evt.preventDefault();
         });
-        document.body.appendChild(canvas);
+
         window.addEventListener('resize', this.resizeCanvas.bind(this), false);
       }
     },

--- a/tests/core/a-scene.test.js
+++ b/tests/core/a-scene.test.js
@@ -68,13 +68,28 @@ suite('a-scene (without renderer)', function () {
   });
 
   suite('setupCanvas', function () {
-    test('adds canvas', function (done) {
-      assert.notOk(document.querySelector('canvas'));
+    test('adds canvas to a-scene element by default', function (done) {
+      assert.notOk(this.el.querySelector('canvas'));
       this.el.setupCanvas();
       process.nextTick(function () {
-        assert.ok(document.querySelector('canvas'));
+        assert.ok(this.el.querySelector('canvas'));
         done();
-      });
+      }.bind(this));
+    });
+
+    test('reuses existing canvas when selector is given', function (done) {
+      var canvas = document.createElement('canvas');
+      canvas.setAttribute('id', 'canvas');
+      document.body.appendChild(canvas);
+      assert.notOk(canvas.classList.contains('a-canvas'));
+
+      this.el.setAttribute('canvas', '#canvas');
+      this.el.setupCanvas();
+      process.nextTick(function () {
+        assert.ok(canvas.classList.contains('a-canvas'));
+        assert.notOk(this.el.querySelector('canvas'));
+        done();
+      }.bind(this));
     });
   });
 


### PR DESCRIPTION
- Changed default behavior of `a-scene` `setupCanvas` to add the `canvas` element inside the `a-scene` element.
- Added `canvas` attribute to `a-scene` element, accepting a query selector pointing to an existing canvas.
- This is a breaking change in the sense that the canvas will be default no longer be created directly inside the `body` element, but rather inside the `a-scene` element, possibly breaking css and javascript selectors applied to the canvas. For this reason, it can probably not be merged without bumping the version and alerting users.
- This current approach of adding canvas to body is a unexpected, and is not compatible with React use cases where `<a-scene>` is removed and added multiple times.
