### PR TITLE
Move browserify dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "license": "MIT",
   "main": "src/index.js",
   "dependencies": {
+    "browserify": "^11.0.1",
+    "browserify-css": "^0.8.2",
     "debug": "^2.2.0",
     "document-register-element": "^0.5.2",
     "es6-promise": "^3.0.2",
@@ -17,8 +19,6 @@
     "webvr-polyfill": "borismus/webvr-polyfill#3f47796"
   },
   "devDependencies": {
-    "browserify": "^11.0.1",
-    "browserify-css": "^0.8.2",
     "budo": "^7.0.2",
     "chai-shallow-deep-equal": "^1.3.0",
     "exorcist": "^0.4.0",


### PR DESCRIPTION
This is more or less mirroring [PR #357](https://github.com/aframevr/aframe/pull/357) `aframe`. When `aframe-core` is added as a project dependency and installed, npm throws an error about missing dependencies during the bundling/browserifying process. [(Additional discussion here)](https://github.com/aframevr/aframe/issues/347)

I'm probably jumping the gun but I had some time to kill. Thanks.
