### PR TITLE
Stereoscopic / Suppress warning / "msrc" param

### DIFF
--- a/lib/VREffect.js
+++ b/lib/VREffect.js
@@ -1,0 +1,199 @@
+/**
+ * @author dmarcos / https://github.com/dmarcos
+ * @author mrdoob / http://mrdoob.com
+ *
+ * WebVR Spec: http://mozvr.github.io/webvr-spec/webvr.html
+ *
+ * Firefox: http://mozvr.com/downloads/
+ * Chromium: https://drive.google.com/folderview?id=0BzudLt22BqGRbW9WTHMtOWMzNjQ&usp=sharing#list
+ *
+ */
+
+THREE.VREffect = function (renderer, onError, leftPreprocess, rightPreprocess) {
+  var vrHMD;
+  var eyeTranslationL, eyeFOVL;
+  var eyeTranslationR, eyeFOVR;
+
+  function gotVRDevices (devices) {
+    for (var i = 0; i < devices.length; i++) {
+      if (devices[i] instanceof HMDVRDevice) {
+        vrHMD = devices[i];
+        break; // We keep the first we encounter
+      }
+    }
+
+    if (vrHMD === undefined) {
+      if (onError) onError('HMD not available');
+    }
+  }
+
+  if (navigator.getVRDevices) {
+    navigator.getVRDevices().then(gotVRDevices);
+  }
+
+  //
+
+  this.scale = 1;
+
+  this.setSize = function (width, height) {
+    renderer.setSize(width, height);
+  };
+
+  // fullscreen
+
+  var isFullscreen = false;
+
+  var canvas = renderer.domElement;
+  var fullscreenchange = canvas.mozRequestFullScreen ? 'mozfullscreenchange' : 'webkitfullscreenchange';
+
+  document.addEventListener(fullscreenchange, function (event) {
+    isFullscreen = document.mozFullScreenElement || document.webkitFullscreenElement;
+  }, false);
+
+  this.setFullScreen = function (boolean) {
+    if (vrHMD === undefined) return;
+    if (isFullscreen === boolean) return;
+
+    if (canvas.mozRequestFullScreen) {
+      canvas.mozRequestFullScreen({
+        vrDisplay: vrHMD
+      });
+    } else if (canvas.webkitRequestFullscreen) {
+      canvas.webkitRequestFullscreen({
+        vrDisplay: vrHMD
+      });
+    }
+  };
+
+  // render
+
+  var cameraL = new THREE.PerspectiveCamera();
+  cameraL.layers.enable(1);
+
+  var cameraR = new THREE.PerspectiveCamera();
+  cameraR.layers.enable(2);
+
+  this.render = function (scene, camera) {
+    if (vrHMD) {
+      var eyeParamsL = vrHMD.getEyeParameters('left');
+      var eyeParamsR = vrHMD.getEyeParameters('right');
+
+      eyeTranslationL = eyeParamsL.eyeTranslation;
+      eyeTranslationR = eyeParamsR.eyeTranslation;
+      eyeFOVL = eyeParamsL.recommendedFieldOfView; 
+      eyeFOVR = eyeParamsR.recommendedFieldOfView;
+
+      if (Array.isArray(scene)) {
+        console.warn('THREE.VREffect.render() no longer supports arrays. Use object.layers instead.');
+        scene = scene[0];
+      }
+
+      var size = renderer.getSize();
+      size.width /= 2;
+
+      renderer.setScissorTest(true);
+      renderer.clear();
+
+      if (camera.parent === null) camera.updateMatrixWorld();
+
+      cameraL.projectionMatrix = fovToProjection(eyeFOVL, true, camera.near, camera.far);
+      cameraR.projectionMatrix = fovToProjection(eyeFOVR, true, camera.near, camera.far);
+
+      camera.matrixWorld.decompose(cameraL.position, cameraL.quaternion, cameraL.scale);
+      camera.matrixWorld.decompose(cameraR.position, cameraR.quaternion, cameraR.scale);
+
+      cameraL.translateX(eyeTranslationL.x * this.scale);
+      cameraR.translateX(eyeTranslationR.x * this.scale);
+
+      // render left eye
+      leftPreprocess && leftPreprocess();
+      renderer.setViewport(0, 0, size.width, size.height);
+      renderer.setScissor(0, 0, size.width, size.height);
+      renderer.render(scene, cameraL);
+
+      // render right eye
+      rightPreprocess && rightPreprocess();
+      renderer.setViewport(size.width, 0, size.width, size.height);
+      renderer.setScissor(size.width, 0, size.width, size.height);
+      renderer.render(scene, cameraR);
+
+      renderer.setScissorTest(false);
+
+      return;
+    }
+
+    // Regular render mode if not HMD
+
+    renderer.render(scene, camera);
+  };
+
+  //
+
+  function fovToNDCScaleOffset (fov) {
+    var pxscale = 2.0 / (fov.leftTan + fov.rightTan);
+    var pxoffset = (fov.leftTan - fov.rightTan) * pxscale * 0.5;
+    var pyscale = 2.0 / (fov.upTan + fov.downTan);
+    var pyoffset = (fov.upTan - fov.downTan) * pyscale * 0.5;
+    return {
+      scale: [pxscale, pyscale],
+      offset: [pxoffset, pyoffset]
+    };
+  }
+
+  function fovPortToProjection (fov, rightHanded, zNear, zFar) {
+    rightHanded = rightHanded === undefined ? true : rightHanded;
+    zNear = zNear === undefined ? 0.01 : zNear;
+    zFar = zFar === undefined ? 10000.0 : zFar;
+
+    var handednessScale = rightHanded ? -1.0 : 1.0;
+
+    // start with an identity matrix
+    var mobj = new THREE.Matrix4();
+    var m = mobj.elements;
+
+    // and with scale/offset info for normalized device coords
+    var scaleAndOffset = fovToNDCScaleOffset(fov);
+
+    // X result, map clip edges to [-w,+w]
+    m[0 * 4 + 0] = scaleAndOffset.scale[0];
+    m[0 * 4 + 1] = 0.0;
+    m[0 * 4 + 2] = scaleAndOffset.offset[0] * handednessScale;
+    m[0 * 4 + 3] = 0.0;
+
+    // Y result, map clip edges to [-w,+w]
+    // Y offset is negated because this proj matrix transforms from world coords with Y=up,
+    // but the NDC scaling has Y=down (thanks D3D?)
+    m[1 * 4 + 0] = 0.0;
+    m[1 * 4 + 1] = scaleAndOffset.scale[1];
+    m[1 * 4 + 2] = -scaleAndOffset.offset[1] * handednessScale;
+    m[1 * 4 + 3] = 0.0;
+
+    // Z result (up to the app)
+    m[2 * 4 + 0] = 0.0;
+    m[2 * 4 + 1] = 0.0;
+    m[2 * 4 + 2] = zFar / (zNear - zFar) * -handednessScale;
+    m[2 * 4 + 3] = (zFar * zNear) / (zNear - zFar);
+
+    // W result (= Z in)
+    m[3 * 4 + 0] = 0.0;
+    m[3 * 4 + 1] = 0.0;
+    m[3 * 4 + 2] = handednessScale;
+    m[3 * 4 + 3] = 0.0;
+
+    mobj.transpose();
+
+    return mobj;
+  }
+
+  function fovToProjection (fov, rightHanded, zNear, zFar) {
+    var DEG2RAD = Math.PI / 180.0;
+    var fovPort = {
+      upTan: Math.tan(fov.upDegrees * DEG2RAD),
+      downTan: Math.tan(fov.downDegrees * DEG2RAD),
+      leftTan: Math.tan(fov.leftDegrees * DEG2RAD),
+      rightTan: Math.tan(fov.rightDegrees * DEG2RAD)
+    };
+
+    return fovPortToProjection(fovPort, rightHanded, zNear, zFar);
+  }
+};

--- a/lib/three.js
+++ b/lib/three.js
@@ -11,6 +11,6 @@ require('../node_modules/three-dev/examples/js/loaders/OBJLoader');  // THREE.OB
 require('../node_modules/three-dev/examples/js/loaders/ColladaLoader');  // THREE.ColladaLoader
 require('../lib/vendor/Raycaster');  // THREE.Raycaster
 require('../node_modules/three-dev/examples/js/controls/VRControls');  // THREE.VRControls
-require('../node_modules/three-dev/examples/js/effects/VREffect');  // THREE.VREffect
+require('./VREffect');  // THREE.VREffect
 
 module.exports = THREE;

--- a/src/components/material.js
+++ b/src/components/material.js
@@ -313,6 +313,7 @@ function loadVideoTexture (material, src, height, width, loadedStereoscopicTextu
   // three.js video texture loader requires a <video>.
   var videoEl = typeof src !== 'string' ? fixVideoAttributes(src) : createVideoEl(material, src, height, width);
   var loaded = function () {
+    videoEl.onloadeddata = null;
     var texture = new THREE.VideoTexture(videoEl);
     texture.minFilter = THREE.LinearFilter;
     texture.needsUpdate = true;
@@ -320,10 +321,10 @@ function loadVideoTexture (material, src, height, width, loadedStereoscopicTextu
     material.needsUpdate = true;
     if (stereoscopicDirection && loadedStereoscopicTexture) loadedStereoscopicTexture();
   };
-  if (videoEl.videoWidth) {
-    loaded();
+  if (typeof src === 'string') {
+    videoEl.onloadeddata = loaded;
   } else {
-    videoEl.onloadedmetadata = loaded;
+    loaded();
   }
 }
 

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -27,6 +27,7 @@ var isMobile = utils.isMobile();
  * @member {number} animationFrameID
  * @member {array} behaviors - Component instances that have registered themselves to be
            updated on every tick.
+ * @member {array} stereoscopicTextures - Stereoscopic textures.
  * @member {object} canvas
  * @member {Element} enterVREl
  * @member {bool} insideIframe
@@ -47,6 +48,7 @@ var AScene = module.exports = registerElement('a-scene', {
     createdCallback: {
       value: function () {
         this.behaviors = [];
+        this.stereoscopicTextures = [];
         this.defaultLightsEnabled = true;
         this.enterVREl = null;
         this.insideIframe = window.top !== window.self;
@@ -112,6 +114,16 @@ var AScene = module.exports = registerElement('a-scene', {
     addBehavior: {
       value: function (behavior) {
         this.behaviors.push(behavior);
+      }
+    },
+
+    /**
+     * @param {object} texture - Stereoscopic texture
+     */
+    addStereoscopicTexture: {
+      value: function (texture) {
+        var index = this.stereoscopicTextures.indexOf(texture);
+        if (index === -1) this.stereoscopicTextures.push(texture);
       }
     },
 
@@ -328,6 +340,16 @@ var AScene = module.exports = registerElement('a-scene', {
         var index = behaviors.indexOf(behavior);
         if (index === -1) { return; }
         behaviors.splice(index, 1);
+      }
+    },
+
+    /**
+     * @param {object} texture - Stereoscopic texture.
+     */
+    removeStereoscopicTexture: {
+      value: function (texture) {
+        var index = this.stereoscopicTextures.indexOf(texture);
+        if (index !== -1) this.stereoscopicTextures.splice(index, 1);
       }
     },
 
@@ -555,7 +577,7 @@ var AScene = module.exports = registerElement('a-scene', {
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         AScene.renderer = renderer;
-        this.stereoRenderer = new THREE.VREffect(renderer);
+        this.stereoRenderer = new THREE.VREffect(renderer, null, this.leftPreprocess.bind(this), this.rightPreprocess.bind(this));
       },
       writable: window.debug
     },
@@ -640,6 +662,7 @@ var AScene = module.exports = registerElement('a-scene', {
      */
     unregisterMaterial: {
       value: function (material) {
+        if (material.map) this.removeStereoscopicTexture(material.map);
         delete this.materials[material.uuid];
       }
     },
@@ -698,6 +721,28 @@ var AScene = module.exports = registerElement('a-scene', {
         if (stats) { stats().update(); }
         this.animationFrameID = window.requestAnimationFrame(
           this.render.bind(this));
+      }
+    },
+
+    /**
+     * Stereo render left preprocess
+     */
+    leftPreprocess: {
+      value: function () {
+        this.stereoscopicTextures.forEach(function (texture) {
+          texture.offset[texture.stereoscopicDirection] = texture.stereoscopicOffset.l;
+        });
+      }
+    },
+
+    /**
+     * Stereo render right preprocess
+     */
+    rightPreprocess: {
+      value: function () {
+        this.stereoscopicTextures.forEach(function (texture) {
+          texture.offset[texture.stereoscopicDirection] = texture.stereoscopicOffset.r;
+        });
       }
     }
   })

--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -37,11 +37,29 @@ function validateSrc (src, isImageCb, isVideoCb) {
   if (!textureEl) { return; }
   isImage = textureEl && textureEl.tagName === 'IMG';
   isVideo = textureEl && textureEl.tagName === 'VIDEO';
-  if (isImage) { return isImageCb(textureEl); }
-  if (isVideo) { return isVideoCb(textureEl); }
-
-  // src is a valid selector but doesn't match with a <img> or <video> element.
-  warn('"%s" does not point to a valid <img> or <video> element', src);
+  if (isImage) {
+    if (textureEl.complete) {
+      return isImageCb(textureEl);
+    } else {
+      textureEl.onload = function () {
+        textureEl.onload = null;
+        return isImageCb(textureEl);
+      };
+    }
+  } else if (isVideo) {
+    if (textureEl.videoWidth) {
+      return isVideoCb(textureEl);
+    } else {
+      textureEl.onloadedmetadata = function () {
+        textureEl.onloadedmetadata = null;
+        return isVideoCb(textureEl);
+      };
+    }
+  } else {
+    // src is a valid selector but doesn't match with a <img> or <video> element.
+    warn('"%s" does not point to a valid <img> or <video> element', src);
+    return;
+  }
 }
 
 /**

--- a/src/utils/src-loader.js
+++ b/src/utils/src-loader.js
@@ -50,8 +50,8 @@ function validateSrc (src, isImageCb, isVideoCb) {
     if (textureEl.videoWidth) {
       return isVideoCb(textureEl);
     } else {
-      textureEl.onloadedmetadata = function () {
-        textureEl.onloadedmetadata = null;
+      textureEl.onloadeddata = function () {
+        textureEl.onloadeddata = null;
         return isVideoCb(textureEl);
       };
     }


### PR DESCRIPTION
## #Stereoscopic source support

Stereoscopic source use set 'src' and 'stereoscopicType'.
stereoscopicType value
'OU':Left eye:Over  / Right eye:Under.
'UO':Left eye:Under / Right eye:Over.
'LR':Left eye:Left  / Right eye:Right.
'RL':Left eye:Right / Right eye:Left.
### Image demo

[Page](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_image_lr.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/aframe_stereoscopic_warning_fix/aframe_image_lr.html)
### Video demo

[Page](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_video_2560x720_rl.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/aframe_stereoscopic_warning_fix/aframe_video_2560x720_rl.html)
### Videosphere demo

[Page](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_videosphere_1920x960_rl.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/aframe_stereoscopic_warning_fix/aframe_videosphere_1920x960_rl.html)
## #Suppress warning

Suppress texture source loading time warning. (But, incomplete. ex. loop play)
![ch_texturesize_warning](https://cloud.githubusercontent.com/assets/309829/12131479/51a30f64-b456-11e5-8368-7d85a9f9fb68.png)
![ff_texturesize_warning](https://cloud.githubusercontent.com/assets/309829/12132183/ac3a706a-b45c-11e5-8311-3349a6ad147e.png)
Compare demo
[Unfixed](https://gtk2k.github.io/aframe_stereoscopic/aframe_videosphere_1280x640_lr.html)
[Fixed](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_videosphere_1280x640_lr.html)
## #"msrc" param

Material component add "msrc" param.
This is mobile source.
[Page](https://gtk2k.github.io/src_switch/aframe_videosphere_src_switch_test.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/src_switch/aframe_videosphere_src_switch_test.html)
