### PR TITLE
Stereoscopic / Suppress warning / "msrc" param (without touching VREffect)

### DIFF
--- a/src/components/material.js
+++ b/src/components/material.js
@@ -1,6 +1,7 @@
 /* global Promise */
 var debug = require('../utils/debug');
 var diff = require('../utils').diff;
+var isMobile = require('../utils').isMobile;
 var registerComponent = require('../core/component').registerComponent;
 var srcLoader = require('../utils/src-loader');
 var THREE = require('../../lib/three');
@@ -13,6 +14,16 @@ var warn = debug('components:material:warn');
 
 var MATERIAL_TYPE_BASIC = 'MeshBasicMaterial';
 var MATERIAL_TYPE_STANDARD = 'MeshStandardMaterial';
+
+var stereoscopicOffsets = {
+  OU: { l: 0, r: 0.5 },
+  UO: { l: 0.5, r: 0 },
+  LR: { l: 0, r: 0.5 },
+  RL: { l: 0.5, r: 0 }
+};
+var stereoscopicOffset = null;
+var stereoscopicDirections = { OU: 'y', UO: 'y', LR: 'x', RL: 'x' };
+var stereoscopicDirection = '';
 
 /**
  * Material component.
@@ -36,6 +47,12 @@ var MATERIAL_TYPE_STANDARD = 'MeshStandardMaterial';
  *         MeshBasicMaterial.
  * @param {string} src - To load a texture. takes a selector to an img/video
  *         element or a direct url().
+ * @param {string} msrc - src for mobile.
+ * @param {string} stereoscopicType - Stereoscopic texture type.
+ *         'OU': Left eye:Over  / Right eye:Under.
+ *         'UO': Left eye:Under / Right eye:Over.
+ *         'LR': Left eye:Left  / Right eye:Right.
+ *         'RL': Left eye:Right / Right eye:Left.
  * @param {boolean} transparent - Whether to render transparent the alpha
  *         channel of a texture (e.g., .png).
  * @param {number} width - Width to render texture.
@@ -53,6 +70,8 @@ module.exports.Component = registerComponent('material', {
     shader: { default: 'standard', oneOf: ['flat', 'standard'] },
     side: { default: 'front', oneOf: ['front', 'back', 'double'] },
     src: { default: '' },
+    msrc: { default: '' },
+    stereoscopicType: { default: '' },
     transparent: { default: false },
     width: { default: 640 }
   },
@@ -76,7 +95,7 @@ module.exports.Component = registerComponent('material', {
     var data = this.data;
     var material;
     var materialType = getMaterialType(data);
-    var src = data.src;
+    var src = isMobile() && data.msrc ? data.msrc : data.src;
 
     if (!oldData || getMaterialType(oldData) !== materialType) {
       material = this.createMaterial(getMaterialData(data), materialType);
@@ -178,7 +197,23 @@ module.exports.Component = registerComponent('material', {
   updateTexture: function (src) {
     var data = this.data;
     var material = this.material;
+    var stereoscopicType = (data.stereoscopicType || '').toUpperCase();
+    var loadedStereoscopicTexture = function () {
+      var texture = this.material.map;
+      var sceneEl = this.el.sceneEl;
+      texture.stereoscopicDirection = stereoscopicDirection;
+      texture.stereoscopicOffset = stereoscopicOffset;
+      texture.repeat[stereoscopicDirection] = 0.5;
+      if (texture) sceneEl.addStereoscopicTexture(texture);
+    }.bind(this);
+    if (material.map) this.el.sceneEl.removeStereoscopicTexture(material.map);
     if (src) {
+      if (stereoscopicType) {
+        data.repeat = ''; // ignore repeat.
+        stereoscopicType = /OU|UO|LR|RL/.test(stereoscopicType) ? stereoscopicType : 'OU'; // Default Youtube type (='OU').
+        stereoscopicOffset = stereoscopicOffsets[stereoscopicType];
+        stereoscopicDirection = stereoscopicDirections[stereoscopicType];
+      }
       if (src !== this.textureSrc) {
         // Texture added or changed.
         this.textureSrc = src;
@@ -189,8 +224,8 @@ module.exports.Component = registerComponent('material', {
       material.map = null;
       material.needsUpdate = true;
     }
-    function loadImage (src) { loadImageTexture(material, src, data.repeat); }
-    function loadVideo (src) { loadVideoTexture(material, src, data.width, data.height); }
+    function loadImage (src) { loadImageTexture(material, src, data.repeat, loadedStereoscopicTexture); }
+    function loadVideo (src) { loadVideoTexture(material, src, data.width, data.height, loadedStereoscopicTexture); }
   }
 });
 
@@ -200,8 +235,9 @@ module.exports.Component = registerComponent('material', {
  * @param {object} material - three.js material.
  * @param {string|object} src - An <img> element or url to an image file.
  * @param {string} repeat - X and Y value for size of texture repeating (in UV units).
+ * @param {function} loadedStereoscopicTexture - Stereoscopic texture loaded callback.
  */
-function loadImageTexture (material, src, repeat) {
+function loadImageTexture (material, src, repeat, loadedStereoscopicTexture) {
   var isEl = typeof src !== 'string';
 
   var onLoad = createTexture;
@@ -232,6 +268,7 @@ function loadImageTexture (material, src, repeat) {
     material.map = texture;
     texture.needsUpdate = true;
     material.needsUpdate = true;
+    if (stereoscopicDirection && loadedStereoscopicTexture) loadedStereoscopicTexture();
   }
 }
 
@@ -270,15 +307,25 @@ function createVideoEl (material, src, width, height) {
  * @param {string} src - Url to a video file.
  * @param {number} width - Width of the video.
  * @param {number} height - Height of the video.
+ * @param {function} loadedStereoscopicTexture - Stereoscopic texture loaded callback.
 */
-function loadVideoTexture (material, src, height, width) {
+function loadVideoTexture (material, src, height, width, loadedStereoscopicTexture) {
   // three.js video texture loader requires a <video>.
   var videoEl = typeof src !== 'string' ? fixVideoAttributes(src) : createVideoEl(material, src, height, width);
-  var texture = new THREE.VideoTexture(videoEl);
-  texture.minFilter = THREE.LinearFilter;
-  texture.needsUpdate = true;
-  material.map = texture;
-  material.needsUpdate = true;
+  var loaded = function () {
+    videoEl.onloadeddata = null;
+    var texture = new THREE.VideoTexture(videoEl);
+    texture.minFilter = THREE.LinearFilter;
+    texture.needsUpdate = true;
+    material.map = texture;
+    material.needsUpdate = true;
+    if (stereoscopicDirection && loadedStereoscopicTexture) loadedStereoscopicTexture();
+  };
+  if (typeof src === 'string') {
+    videoEl.onloadeddata = loaded;
+  } else {
+    loaded();
+  }
 }
 
 /**

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -27,6 +27,7 @@ var isMobile = utils.isMobile();
  * @member {number} animationFrameID
  * @member {array} behaviors - Component instances that have registered themselves to be
            updated on every tick.
+ * @member {array} stereoscopicTextures - Stereoscopic textures.
  * @member {object} canvas
  * @member {Element} enterVREl
  * @member {bool} insideIframe
@@ -47,6 +48,7 @@ var AScene = module.exports = registerElement('a-scene', {
     createdCallback: {
       value: function () {
         this.behaviors = [];
+        this.stereoscopicTextures = [];
         this.defaultLightsEnabled = true;
         this.enterVREl = null;
         this.insideIframe = window.top !== window.self;
@@ -112,6 +114,16 @@ var AScene = module.exports = registerElement('a-scene', {
     addBehavior: {
       value: function (behavior) {
         this.behaviors.push(behavior);
+      }
+    },
+
+    /**
+     * @param {object} texture - Stereoscopic texture
+     */
+    addStereoscopicTexture: {
+      value: function (texture) {
+        var index = this.stereoscopicTextures.indexOf(texture);
+        if (index === -1) this.stereoscopicTextures.push(texture);
       }
     },
 
@@ -328,6 +340,16 @@ var AScene = module.exports = registerElement('a-scene', {
         var index = behaviors.indexOf(behavior);
         if (index === -1) { return; }
         behaviors.splice(index, 1);
+      }
+    },
+
+    /**
+     * @param {object} texture - Stereoscopic texture.
+     */
+    removeStereoscopicTexture: {
+      value: function (texture) {
+        var index = this.stereoscopicTextures.indexOf(texture);
+        if (index !== -1) this.stereoscopicTextures.splice(index, 1);
       }
     },
 
@@ -555,7 +577,17 @@ var AScene = module.exports = registerElement('a-scene', {
         renderer.setPixelRatio(window.devicePixelRatio);
         renderer.sortObjects = false;
         AScene.renderer = renderer;
-        this.stereoRenderer = new THREE.VREffect(renderer);
+        var self = this;
+        renderer.orgSetViewport = renderer.setViewport;
+        renderer.setViewport = function (left, top, width, height) {
+          if (left === 0) {
+            self.leftPreprocess();
+          } else {
+            self.rightPreprocess();
+          }
+          renderer.orgSetViewport(left, top, width, height);
+        };
+        this.stereoRenderer = new THREE.VREffect(renderer, null, this.leftPreprocess.bind(this), this.rightPreprocess.bind(this));
       },
       writable: window.debug
     },
@@ -640,6 +672,7 @@ var AScene = module.exports = registerElement('a-scene', {
      */
     unregisterMaterial: {
       value: function (material) {
+        if (material.map) this.removeStereoscopicTexture(material.map);
         delete this.materials[material.uuid];
       }
     },
@@ -698,6 +731,28 @@ var AScene = module.exports = registerElement('a-scene', {
         if (stats) { stats().update(); }
         this.animationFrameID = window.requestAnimationFrame(
           this.render.bind(this));
+      }
+    },
+
+    /**
+     * Stereo render left preprocess
+     */
+    leftPreprocess: {
+      value: function () {
+        this.stereoscopicTextures.forEach(function (texture) {
+          texture.offset[texture.stereoscopicDirection] = texture.stereoscopicOffset.l;
+        });
+      }
+    },
+
+    /**
+     * Stereo render right preprocess
+     */
+    rightPreprocess: {
+      value: function () {
+        this.stereoscopicTextures.forEach(function (texture) {
+          texture.offset[texture.stereoscopicDirection] = texture.stereoscopicOffset.r;
+        });
       }
     }
   })

--- a/src/core/a-scene.js
+++ b/src/core/a-scene.js
@@ -587,7 +587,7 @@ var AScene = module.exports = registerElement('a-scene', {
           }
           renderer.orgSetViewport(left, top, width, height);
         };
-        this.stereoRenderer = new THREE.VREffect(renderer, null, this.leftPreprocess.bind(this), this.rightPreprocess.bind(this));
+        this.stereoRenderer = new THREE.VREffect(renderer);
       },
       writable: window.debug
     },


### PR DESCRIPTION
## #Stereoscopic source support

Stereoscopic source use set 'src' and 'stereoscopicType'.
stereoscopicType value
'OU':Left eye:Over  / Right eye:Under.
'UO':Left eye:Under / Right eye:Over.
'LR':Left eye:Left  / Right eye:Right.
'RL':Left eye:Right / Right eye:Left.
### Image demo

[Page](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_image_lr.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/aframe_stereoscopic_warning_fix/aframe_image_lr.html)
### Video demo

[Page](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_video_2560x720_rl.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/aframe_stereoscopic_warning_fix/aframe_video_2560x720_rl.html)
### Videosphere demo

[Page](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_videosphere_1920x960_rl.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/aframe_stereoscopic_warning_fix/aframe_videosphere_1920x960_rl.html)
## #Suppress warning

Suppress texture source loading time warning. (But, incomplete. ex. loop play)
![ch_texturesize_warning](https://cloud.githubusercontent.com/assets/309829/12131479/51a30f64-b456-11e5-8368-7d85a9f9fb68.png)
![ff_texturesize_warning](https://cloud.githubusercontent.com/assets/309829/12132183/ac3a706a-b45c-11e5-8311-3349a6ad147e.png)
Compare demo
[Unfixed](https://gtk2k.github.io/aframe_stereoscopic/aframe_videosphere_1280x640_lr.html)
[Fixed](https://gtk2k.github.io/aframe_stereoscopic_warning_fix/aframe_videosphere_1280x640_lr.html)
## #"msrc" param

Material component add "msrc" param.
This is mobile source.
[Page](https://gtk2k.github.io/src_switch/aframe_videosphere_src_switch_test.html)
[Code](https://github.com/gtk2k/gtk2k.github.io/blob/master/src_switch/aframe_videosphere_src_switch_test.html)
